### PR TITLE
ci: Add Amplify config

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install -g pnpm
+        - pnpm install
+    build:
+      commands:
+        - pnpm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .next/cache/**/*
+      - node_modules/**/*


### PR DESCRIPTION
Implements #4 

This PR adds the build configuration for AWS Amplify. 

I've configured the deployment itself in the AWS console, under the "Global Food Twin" workspace. Deployments are currently configured for pushes to the `development` branch. You can preview the deployed app here: https://develop.d2wdw1hzf2w0yx.amplifyapp.com