### PR TITLE
Ingest flows

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5433/food-twin"
 DUMP_FILE_PATH="./seed-data/db_dump"
 
-SEED_DATA_PATH="./seed-data/v2"
+SEED_DATA_PATH="./seed-data/v3"
 
 # Environment variables for client usage
 NEXT_PUBLIC_USE_STATELY_INSPECTOR=false

--- a/prisma/migrations/20240814100608_add_inland_port/migration.sql
+++ b/prisma/migrations/20240814100608_add_inland_port/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NodeType" ADD VALUE 'INLAND_PORT';

--- a/prisma/migrations/20240814101132_add_rail_station/migration.sql
+++ b/prisma/migrations/20240814101132_add_rail_station/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NodeType" ADD VALUE 'RAIL_STATION';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Area {
 enum NodeType {
   MARITIME
   PORT
+  INLAND_PORT
 }
 
 model Node {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,9 +23,10 @@ model Area {
 }
 
 enum NodeType {
+  INLAND_PORT
   MARITIME
   PORT
-  INLAND_PORT
+  RAIL_STATION
 }
 
 model Node {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -96,6 +96,7 @@ async function ingestData() {
       `-nln Area_limits_temp -overwrite -nlt MULTIPOLYGON -lco GEOMETRY_NAME=limits -sql "SELECT ID as id, geom as limits FROM ${ADMIN_LIMITS_TABLENAME}"`
     );
     await prisma.$executeRaw`UPDATE "Area" SET "limits" = (SELECT ST_Transform(limits, 3857) FROM "area_limits_temp" WHERE "Area"."id" = "area_limits_temp"."id")`;
+    await prisma.$executeRaw`DROP TABLE IF EXISTS "area_limits_temp"`;
     console.log(
       `Ingested area limits (${msToSeconds(performance.now() - ingestLimitsStart)}s)`
     );
@@ -216,14 +217,10 @@ async function ingestData() {
         `Ingested file '${file}' (${msToSeconds(performance.now() - ingestFlowsStart)}s)`
       );
     }
-
+    await prisma.$executeRaw`DROP TABLE IF EXISTS "flows_temp"`;
     console.log(
       `Data ingestion complete in ${msToMinutes(performance.now() - ingestDataStart)} minutes.`
     );
-
-    // Clear temporary tables
-    await prisma.$executeRaw`DROP TABLE IF EXISTS "area_limits_temp"`;
-    await prisma.$executeRaw`DROP TABLE IF EXISTS "flows_temp"`;
   } catch (error) {
     console.error("Error ingesting data:", error);
   } finally {


### PR DESCRIPTION
Closes https://github.com/earth-genome/foodtwin-global-app/issues/26

Opening this for visibility, this aims to implement the ingest workflow for the food flows.

We scaffolded the ingest script in #8 and #12, which currently covers the following datasets:

- Admin area centroids
- Admin area limits
- Maritime nodes
- Maritime edges

Considering that the flow dataset depends on others (land/sea edges, food groups), I suggest we work on the files sequentially, ensuring each dataset can be ingested correctly before moving to the next one.

At the moment, we are working on ingesting the edges for land. In the v3 data folder, there is the file `Geometry_Landmapping_hexcode_complete.csv`, which includes the geometries but not the references nodes (e.g., `rail1870326_SDN-rail1870327_SDN`).

Next steps:

- [ ] Add land nodes file to v3 folder
- [ ] Land nodes ingest step
- [ ] Land edges ingest step (already scaffolded, but needs the nodes to be completed)
- [ ] Food groups ingest (file `UniqueFG1_FG2.csv` seems to include the required data)
- [ ] Flows ingest

cc @cameronkruse  @faustoperez  @oliverroick @wrynearson 