### PR TITLE
feat: Add production area popup

### DIFF
--- a/src/app/components/MapPopup.tsx
+++ b/src/app/components/MapPopup.tsx
@@ -1,0 +1,33 @@
+import { Popup } from "react-map-gl";
+import { EPageType } from "@/types/components";
+
+import { getTypeIcon } from "./icons/getTypeIcon";
+import "./css/popup.css";
+
+interface IMapPopup {
+  id: string;
+  label: string;
+  itemType: EPageType;
+  longitude: number;
+  latitude: number;
+}
+
+function MapPopup({ id, label, itemType, longitude, latitude }: IMapPopup) {
+  return (
+    <Popup
+      key={id}
+      anchor="bottom"
+      longitude={longitude}
+      latitude={latitude}
+      maxWidth="250px"
+      closeButton={false}
+    >
+      <div className="flex gap-2 items-center font-header tracking-tighter text-white bg-neutral-800 p-2 rounded">
+        {getTypeIcon(itemType)}
+        <span>{label}</span>
+      </div>
+    </Popup>
+  );
+}
+
+export default MapPopup;

--- a/src/app/components/MapPopup.tsx
+++ b/src/app/components/MapPopup.tsx
@@ -21,6 +21,7 @@ function MapPopup({ id, label, itemType, longitude, latitude }: IMapPopup) {
       latitude={latitude}
       maxWidth="250px"
       closeButton={false}
+      offset={12}
     >
       <div className="flex gap-2 items-center font-header tracking-tighter text-white bg-neutral-800 p-2 rounded">
         {getTypeIcon(itemType)}

--- a/src/app/components/PageHeader.tsx
+++ b/src/app/components/PageHeader.tsx
@@ -1,10 +1,8 @@
 import { Link } from "@nextui-org/react";
 import { X } from "@phosphor-icons/react/dist/ssr";
 
-import Area from "@/app/components/icons/Area";
-import Node from "@/app/components/icons/Node";
-import Route from "@/app/components/icons/Route";
 import { EPageType, IPageHeader } from "@/types/components";
+import { getTypeIcon } from "./icons/getTypeIcon";
 
 function getTypeLabel(itemType: EPageType) {
   switch (itemType) {
@@ -14,17 +12,6 @@ function getTypeLabel(itemType: EPageType) {
       return "Producing Areas";
     case EPageType.node:
       return "Ports & Depots";
-  }
-}
-
-function getTypeIcon(itemType: EPageType) {
-  switch (itemType) {
-    case EPageType.route:
-      return <Route />;
-    case EPageType.area:
-      return <Area />;
-    case EPageType.node:
-      return <Node />;
   }
 }
 

--- a/src/app/components/css/popup.css
+++ b/src/app/components/css/popup.css
@@ -1,7 +1,6 @@
 .maplibregl-popup-content {
   padding: 0;
   background: none;
-  margin-bottom: .5rem;
 }
 
 .maplibregl-popup-tip {

--- a/src/app/components/css/popup.css
+++ b/src/app/components/css/popup.css
@@ -1,0 +1,9 @@
+.maplibregl-popup-content {
+  padding: 0;
+  background: none;
+  margin-bottom: .5rem;
+}
+
+.maplibregl-popup-tip {
+  display: none;
+}

--- a/src/app/components/icons/getTypeIcon.tsx
+++ b/src/app/components/icons/getTypeIcon.tsx
@@ -1,0 +1,15 @@
+import { EPageType } from "@/types/components";
+import Area from "./Area";
+import Node from "./Node";
+import Route from "./Route";
+
+export function getTypeIcon(itemType: EPageType) {
+  switch (itemType) {
+    case EPageType.route:
+      return <Route />;
+    case EPageType.area:
+      return <Area />;
+    case EPageType.node:
+      return <Node />;
+  }
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,0 +1,4 @@
+export interface ProductionArea {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
Implements #29: Adds popup on hover showing the area name and highlights the area on the map.

<img width="982" alt="Screenshot 2024-09-06 at 13 20 57" src="https://github.com/user-attachments/assets/83871335-193b-4e68-806d-59d6e6e7c5d6">

- Adds `MapPopup`, which renders the popup using MapLibre's `Popup`
- Adds `highlightArea` state, which holds information about the currently highlighted feature. This is set in `onMouseMove`, which also updates the popup position above the mouse pointer.
- Adds layer `area-hovered-polygon` to the map. The layer also uses the `area-tiles` source, but with the `highlightFilter`, which limits the visualised data to the highlighted polygon. 