### PR TITLE
List chart

### DIFF
--- a/src/app/components/PageSection.tsx
+++ b/src/app/components/PageSection.tsx
@@ -1,5 +1,10 @@
 import { formatNumber } from "@/utils/numbers";
-import { Button, Tooltip } from "@nextui-org/react";
+import {
+  Button,
+  Tooltip,
+  Tabs as NextUiTabs,
+  TabsProps,
+} from "@nextui-org/react";
 import { Info } from "@phosphor-icons/react/dist/ssr";
 
 interface ISectionHeader {
@@ -63,6 +68,22 @@ export function Metric({ label, value, unit }: IMetric) {
       <p className="text-neutral-500 text-xs">{label}</p>
       <p className="text-2xl">{formatNumber(value)}</p>
       {unit && <p className="text-xs font-bold mt-1">{unit}</p>}
+    </div>
+  );
+}
+
+export function Tabs({ children, ...props }: TabsProps) {
+  return (
+    <div className="my-8">
+      <NextUiTabs
+        {...props}
+        fullWidth
+        classNames={{
+          tab: "font-header text-sm tracking-tighter",
+        }}
+      >
+        {children}
+      </NextUiTabs>
     </div>
   );
 }

--- a/src/app/components/charts/ListBars.tsx
+++ b/src/app/components/charts/ListBars.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { useMemo } from "react";
+
+interface IDataPoint {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+interface IBar extends IDataPoint {
+  fraction: number;
+  showPercentage?: boolean;
+  unit: string;
+}
+
+interface IListBars {
+  showPercentage?: boolean;
+  data: IDataPoint[];
+  unit: string;
+}
+
+function Bar({
+  label,
+  value,
+  color = "#2E6FFF",
+  fraction,
+  showPercentage,
+  unit,
+}: IBar) {
+  const percent = (fraction * 100).toFixed(2);
+
+  return (
+    <div className="my-4">
+      <div className="flex text-sm mb-1">
+        <div className="flex-grow">
+          <span aria-hidden="true" className="mr-2" style={{ color }}>
+            &#9679;
+          </span>
+          {label}
+        </div>
+        <div>
+          {value} {unit}
+          {showPercentage && (
+            <>
+              <span className="text-neutral-400" aria-hidden="true">
+                {" "}
+                |{" "}
+              </span>{" "}
+              {percent}%
+            </>
+          )}
+        </div>
+      </div>
+      <div className="bg-neutral-200 h-2">
+        <div
+          style={{ backgroundColor: color, width: `${percent}%` }}
+          className="h-2"
+        ></div>
+      </div>
+    </div>
+  );
+}
+
+function ListBars({ data, showPercentage, unit }: IListBars) {
+  const sum = useMemo(() => {
+    return data.reduce((sum, { value }) => sum + value, 0);
+  }, [data]);
+
+  return (
+    <>
+      {data.map(({ label, value, color }) => {
+        const fraction = value / sum;
+        return (
+          <Bar
+            key={label}
+            label={label}
+            value={value}
+            color={color}
+            fraction={fraction}
+            showPercentage={showPercentage}
+            unit={unit}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export default ListBars;

--- a/src/app/components/charts/ListBars.tsx
+++ b/src/app/components/charts/ListBars.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { useMemo } from "react";
 
 interface IDataPoint {

--- a/src/app/components/charts/index.ts
+++ b/src/app/components/charts/index.ts
@@ -1,0 +1,3 @@
+import ListBars from "./ListBars";
+
+export { ListBars };

--- a/src/app/sandbox/components/page.tsx
+++ b/src/app/sandbox/components/page.tsx
@@ -1,11 +1,15 @@
+"use client";
+
 import PageHeader from "@/app/components/PageHeader";
 import {
   Metric,
   MetricRow,
   PageSection,
   SectionHeader,
+  Tabs,
 } from "@/app/components/PageSection";
 import { EPageType } from "@/types/components";
+import { Tab } from "@nextui-org/react";
 
 export default function Components() {
   return (
@@ -74,6 +78,15 @@ export default function Components() {
             <Metric label="GDP per capita" value={49447} unit="2011 USD$" />
           </MetricRow>
         </PageSection>
+      </div>
+
+      <h2>Charts</h2>
+
+      <div className="w-[480px] mb-8">
+        <Tabs>
+          <Tab title="Food groups">Food groups content</Tab>
+          <Tab title="Nutritional value">Nutritional value content</Tab>
+        </Tabs>
       </div>
     </div>
   );

--- a/src/app/sandbox/components/page.tsx
+++ b/src/app/sandbox/components/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ListBars } from "@/app/components/charts";
 import PageHeader from "@/app/components/PageHeader";
 import {
   Metric,
@@ -84,8 +85,39 @@ export default function Components() {
 
       <div className="w-[480px] mb-8">
         <Tabs>
-          <Tab title="Food groups">Food groups content</Tab>
-          <Tab title="Nutritional value">Nutritional value content</Tab>
+          <Tab title="Food groups">
+            <ListBars
+              showPercentage
+              unit="million MMt"
+              data={[
+                {
+                  label: "🥛 Dairy and Eggs",
+                  value: 14.13,
+                  color: "#76B7B2",
+                },
+                {
+                  label: "🥔 Starches",
+                  value: 1.1,
+                  color: "#4E79A7",
+                },
+              ]}
+            />
+          </Tab>
+          <Tab title="Nutritional value">
+            <ListBars
+              unit="Millions people’s needs"
+              data={[
+                {
+                  label: "🍔 Calories",
+                  value: 20000,
+                },
+                {
+                  label: "🥩 Protein",
+                  value: 10000,
+                },
+              ]}
+            />
+          </Tab>
         </Tabs>
       </div>
     </div>


### PR DESCRIPTION
Adds `ListBar` component, which renders the listed bars for food groups and nutrition.

<img width="504" alt="Screenshot 2024-09-11 at 14 54 44" src="https://github.com/user-attachments/assets/657a4e11-c918-42c1-bef3-4b023b9af36e">

**Example use**

Prepare the data as follows:

```
const data = [{
  label: "Dairy and Eggs"
  value: 12.2,
  color: "red"
}, {
  label: "Starches"
  value: 12.2,
  color: "blue"
}]
```

and use it like:

```
<ListBars data={data} unit="tonnes" showPercentage />
```

- The `color` prop in the data points is optional. If no color is provided, we render a default colour. 
- The `showPercentage` prop of `ListBars` is optional, if not `true` we don't show the percentage points after the value.
