### PR TITLE
feat: Add welcome page modal

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,13 +1,69 @@
+"use client";
+
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  useDisclosure,
+} from "@nextui-org/react";
 import Menu from "../components/menu";
 import Globe from "./globe";
+import { HandPointing } from "@phosphor-icons/react/dist/ssr";
+import { useEffect } from "react";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  useEffect(() => {
+    const hasVisited = localStorage.getItem("foodtwin:visited");
+    if (!hasVisited) {
+      onOpen();
+      localStorage.setItem("foodtwin:visited", "true");
+    }
+  }, [onOpen]);
+
   return (
     <>
       <Menu />
       <div className="flex h-screen">
         <Globe />
         {children}
+        <Modal isOpen={isOpen} hideCloseButton>
+          <ModalContent className="rounded">
+            <ModalBody className="bg-neutral-800 text-neutral-200 font-header p-6">
+              <div className="bg-neutral-700 text-center rounded p-2 mb-4">
+                <h1 className="font-header uppercase tracking-tighter mb-2">
+                  Welcome to the Food Twin Map
+                </h1>
+                <p className="text-neutral-400 text-sm italic font-body">
+                  By{" "}
+                  <a
+                    href="https://theplotline.org"
+                    className="not-italic ml-1 underline"
+                  >
+                    The Plotline
+                  </a>
+                </p>
+              </div>
+              <div className="flex gap-4 items-center mb-4">
+                <div>
+                  <HandPointing size={32} />
+                </div>
+                <p className="text-sm tracking-tight">
+                  Discover where food is produced and how it travels around the
+                  world by selecting any region, port, or transport route.
+                </p>
+              </div>
+              <Button
+                className="rounded text-sm text-white bg-accent-warm-400"
+                onClick={() => onClose()}
+              >
+                Explore Food Flows
+              </Button>
+            </ModalBody>
+          </ModalContent>
+        </Modal>
       </div>
     </>
   );

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,69 +1,15 @@
-"use client";
-
-import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalContent,
-  useDisclosure,
-} from "@nextui-org/react";
 import Menu from "../components/menu";
 import Globe from "./globe";
-import { HandPointing } from "@phosphor-icons/react/dist/ssr";
-import { useEffect } from "react";
+import WelcomeModal from "./welcome-modal";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-
-  useEffect(() => {
-    const hasVisited = localStorage.getItem("foodtwin:visited");
-    if (!hasVisited) {
-      onOpen();
-      localStorage.setItem("foodtwin:visited", "true");
-    }
-  }, [onOpen]);
-
   return (
     <>
       <Menu />
       <div className="flex h-screen">
         <Globe />
         {children}
-        <Modal isOpen={isOpen} hideCloseButton>
-          <ModalContent className="rounded">
-            <ModalBody className="bg-neutral-800 text-neutral-200 font-header p-6">
-              <div className="bg-neutral-700 text-center rounded p-2 mb-4">
-                <h1 className="font-header uppercase tracking-tighter mb-2">
-                  Welcome to the Food Twin Map
-                </h1>
-                <p className="text-neutral-400 text-sm italic font-body">
-                  By{" "}
-                  <a
-                    href="https://theplotline.org"
-                    className="not-italic ml-1 underline"
-                  >
-                    The Plotline
-                  </a>
-                </p>
-              </div>
-              <div className="flex gap-4 items-center mb-4">
-                <div>
-                  <HandPointing size={32} />
-                </div>
-                <p className="text-sm tracking-tight">
-                  Discover where food is produced and how it travels around the
-                  world by selecting any region, port, or transport route.
-                </p>
-              </div>
-              <Button
-                className="rounded text-sm text-white bg-accent-warm-400"
-                onClick={() => onClose()}
-              >
-                Explore Food Flows
-              </Button>
-            </ModalBody>
-          </ModalContent>
-        </Modal>
+        <WelcomeModal />
       </div>
     </>
   );

--- a/src/app/(home)/welcome-modal.tsx
+++ b/src/app/(home)/welcome-modal.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect } from "react";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  useDisclosure,
+} from "@nextui-org/react";
+import { HandPointing } from "@phosphor-icons/react/dist/ssr";
+
+export default function WelcomeModal() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  useEffect(() => {
+    const hasVisited = localStorage.getItem("foodtwin:visited");
+    if (!hasVisited) {
+      onOpen();
+      localStorage.setItem("foodtwin:visited", "true");
+    }
+  }, [onOpen]);
+
+  return (
+    <Modal isOpen={isOpen} hideCloseButton>
+      <ModalContent className="rounded">
+        <ModalBody className="bg-neutral-800 text-neutral-200 font-header p-6">
+          <div className="bg-neutral-700 text-center rounded p-2 mb-4">
+            <h1 className="font-header uppercase tracking-tighter mb-2">
+              Welcome to the Food Twin Map
+            </h1>
+            <p className="text-neutral-400 text-sm italic font-body">
+              By{" "}
+              <a
+                href="https://theplotline.org"
+                className="not-italic ml-1 underline"
+              >
+                The Plotline
+              </a>
+            </p>
+          </div>
+          <div className="flex gap-4 items-center mb-4">
+            <div>
+              <HandPointing size={32} />
+            </div>
+            <p className="text-sm tracking-tight">
+              Discover where food is produced and how it travels around the
+              world by selecting any region, port, or transport route.
+            </p>
+          </div>
+          <Button
+            className="rounded text-sm text-white bg-accent-warm-400"
+            onClick={() => onClose()}
+          >
+            Explore Food Flows
+          </Button>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Implements #48 

- Adds a modal to the home page with basic instructions for the site
- We only show the modal if `food twin:visited` is not present in local storage. We set `food twin:visited` on first visit to the site, thus only showing the model on the first visit. 