### PR TITLE
Fix mouseout handling

### DIFF
--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -62,6 +62,12 @@ function GlobeInner() {
     });
   }, []);
 
+  const handleMouseOut = useCallback(() => {
+    actorRef.send({
+      type: "event:map:mouseout",
+    });
+  }, [actorRef]);
+
   useEffect(() => {
     actorRef.send({
       type: "event:page:mount",
@@ -94,17 +100,6 @@ function GlobeInner() {
     }
   }, []);
 
-  // Enable/disable map mousemove
-  useEffect(() => {
-    if (!mapRef.current) return;
-
-    if (eventHandlers.mousemove) {
-      mapRef.current.on("mousemove", handleMouseMove);
-    } else {
-      mapRef.current.off("mousemove", handleMouseMove);
-    }
-  }, [handleMouseMove, eventHandlers.mousemove, mapRef.current]);
-
   return (
     <div className="flex-1 bg-gray-100 flex items-center justify-center">
       <div className="relative w-full h-full overflow-hidden">
@@ -119,6 +114,8 @@ function GlobeInner() {
               mapRef: mapRef.current as MapRef,
             });
           }}
+          onMouseMove={eventHandlers.mousemove ? handleMouseMove : undefined}
+          onMouseOut={eventHandlers.mousemove ? handleMouseOut : undefined}
           style={{ width: "100%", height: "100%" }}
           mapStyle={mapboxStyleUrl}
         >

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -66,6 +66,11 @@ export const globeViewMachine = createMachine(
             actions: "action:setHighlightedArea",
           },
 
+          "event:map:mouseout": {
+            target: "world:view",
+            actions: "action:clearHighlightedArea",
+          },
+
           "event:url:enter": {
             target: "page:load",
             reenter: true,
@@ -123,6 +128,11 @@ export const globeViewMachine = createMachine(
           "event:map:mousemove": {
             target: "area:view",
             actions: "action:setHighlightedArea",
+          },
+
+          "event:map:mouseout": {
+            target: "area:view",
+            actions: "action:clearHighlightedArea",
           },
 
           "event:url:enter": {
@@ -236,6 +246,26 @@ export const globeViewMachine = createMachine(
                 latitude: event.mapEvent.lngLat.lat,
               }
             : null,
+        };
+      }),
+      "action:clearHighlightedArea": assign(({ event, context }) => {
+        assertEvent(event, "event:map:mouseout");
+
+        const { highlightedArea, mapRef } = context;
+
+        if (!mapRef) {
+          return {};
+        }
+
+        if (highlightedArea) {
+          mapRef.setFeatureState(highlightedArea, {
+            hover: false,
+          });
+        }
+
+        return {
+          highlightedArea: null,
+          mapPopup: null,
         };
       }),
       "action:setCurrentArea": assign(({ event }) => {

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -24,6 +24,10 @@ interface ActionSetHighlightedArea {
   MapPopup: IMapPopup | null;
 }
 
+interface ActionClearHighlightedArea {
+  type: "action:clearHighlightedArea";
+}
+
 interface ActionSetCurrentAreaId {
   type: "action:setCurrentAreaId";
   currentAreaId: string;
@@ -48,6 +52,7 @@ export type StateActions =
   | ActionParseUrl
   | ActionSetMapRef
   | ActionSetHighlightedArea
+  | ActionClearHighlightedArea
   | ActionSetCurrentAreaId
   | ActionSetCurrentArea
   | ActionSetAreaMapView

--- a/src/app/components/map/state/types/events.ts
+++ b/src/app/components/map/state/types/events.ts
@@ -21,6 +21,10 @@ interface EventMapMouseMove {
   mapEvent: MapMouseEvent;
 }
 
+interface EventMapMouseOut {
+  type: "event:map:mouseout";
+}
+
 interface EventAreaSelect {
   type: "event:area:select";
   areaId: string;
@@ -45,4 +49,5 @@ export type StateEvents =
   | EventMapMouseMove
   | EventAreaSelect
   | EventFetchAreaDone
-  | EventAreaClear;
+  | EventAreaClear
+  | EventMapMouseOut;


### PR DESCRIPTION
Fixes #60, Fixes #54: Handle mouse out events on the map and clear the popup and highlighted area. 