### PR TITLE
feat: Include sidebar width in fit-bounds padding

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -8,6 +8,7 @@ import {
   PageSection,
   SectionHeader,
 } from "@/app/components/page-section";
+import { SIDEBAR_WIDTH } from "@/app/config";
 
 const AreaPage = async ({
   params,
@@ -36,7 +37,7 @@ const AreaPage = async ({
   });
 
   return (
-    <div className="w-[480px]">
+    <div className={`w-[${SIDEBAR_WIDTH}px]`}>
       <PageHeader title={area.name} itemType={EItemType.area} />
       <PageSection>
         <SectionHeader label="Food Produced" />

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -37,7 +37,9 @@ const AreaPage = async ({
   });
 
   return (
-    <div className={`w-[${SIDEBAR_WIDTH}px]`}>
+    <div
+      className={`w-[${SIDEBAR_WIDTH}px] absolute top-0 right-0 bottom-0 bg-white`}
+    >
       <PageHeader title={area.name} itemType={EItemType.area} />
       <PageSection>
         <SectionHeader label="Food Produced" />

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -8,7 +8,6 @@ import {
   PageSection,
   SectionHeader,
 } from "@/app/components/page-section";
-import { SIDEBAR_WIDTH } from "@/app/config";
 
 const AreaPage = async ({
   params,
@@ -37,9 +36,7 @@ const AreaPage = async ({
   });
 
   return (
-    <div
-      className={`w-[${SIDEBAR_WIDTH}px] absolute top-0 right-0 bottom-0 bg-white`}
-    >
+    <div className={`w-[480px] bg-white`}>
       <PageHeader title={area.name} itemType={EItemType.area} />
       <PageSection>
         <SectionHeader label="Food Produced" />

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -98,7 +98,7 @@ function GlobeInner() {
   }, []);
 
   return (
-    <div className="absolute top-0 right-0 bottom-0 left-0 overflow-hidden">
+    <div className="flex flex-col w-full h-full relative">
       <Legend />
       <Map
         mapboxAccessToken={mapboxAccessToken}
@@ -113,7 +113,7 @@ function GlobeInner() {
         }}
         onMouseMove={eventHandlers.mousemove ? handleMouseMove : undefined}
         onMouseOut={eventHandlers.mousemove ? handleMouseOut : undefined}
-        style={{ width: "100%", height: "100%" }}
+        style={{ width: "100%", height: "100%", flex: 1 }}
         mapStyle={mapboxStyleUrl}
       >
         <Source

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -98,62 +98,60 @@ function GlobeInner() {
   }, []);
 
   return (
-    <div className="flex-1 bg-gray-100 flex items-center justify-center">
-      <div className="relative w-full h-full overflow-hidden">
-        <Legend />
-        <Map
-          mapboxAccessToken={mapboxAccessToken}
-          ref={mapRef}
-          initialViewState={worldViewState}
-          onClick={onClick}
-          onLoad={() => {
-            actorRef.send({
-              type: "event:map:mount",
-              mapRef: mapRef.current as MapRef,
-            });
-          }}
-          onMouseMove={eventHandlers.mousemove ? handleMouseMove : undefined}
-          onMouseOut={eventHandlers.mousemove ? handleMouseOut : undefined}
-          style={{ width: "100%", height: "100%" }}
-          mapStyle={mapboxStyleUrl}
+    <div className="absolute top-0 right-0 bottom-0 left-0 overflow-hidden">
+      <Legend />
+      <Map
+        mapboxAccessToken={mapboxAccessToken}
+        ref={mapRef}
+        initialViewState={worldViewState}
+        onClick={onClick}
+        onLoad={() => {
+          actorRef.send({
+            type: "event:map:mount",
+            mapRef: mapRef.current as MapRef,
+          });
+        }}
+        onMouseMove={eventHandlers.mousemove ? handleMouseMove : undefined}
+        onMouseOut={eventHandlers.mousemove ? handleMouseOut : undefined}
+        style={{ width: "100%", height: "100%" }}
+        mapStyle={mapboxStyleUrl}
+      >
+        <Source
+          id="area-tiles"
+          type="vector"
+          tiles={[`${appUrl}/api/tiles/areas/{z}/{x}/{y}`]}
         >
-          <Source
-            id="area-tiles"
-            type="vector"
-            tiles={[`${appUrl}/api/tiles/areas/{z}/{x}/{y}`]}
-          >
-            <Layer
-              id="area-outline"
-              type="line"
-              source-layer="default"
-              paint={{ "line-color": "#000", "line-width": 0.2 }}
-            />
-            <Layer
-              id="area-clickable-polygon"
-              type="fill"
-              source-layer="default"
-              paint={areaStyle as FillLayerSpecification["paint"]}
-            />
-          </Source>
+          <Layer
+            id="area-outline"
+            type="line"
+            source-layer="default"
+            paint={{ "line-color": "#000", "line-width": 0.2 }}
+          />
+          <Layer
+            id="area-clickable-polygon"
+            type="fill"
+            source-layer="default"
+            paint={areaStyle as FillLayerSpecification["paint"]}
+          />
+        </Source>
 
-          <Source
-            id="foodgroups-source"
-            type="vector"
-            url="mapbox://devseed.dlel0qkq"
-          >
-            <Layer
-              id="foodgroups-layer"
-              type="circle"
-              source-layer="foodgroup2max"
-              paint={foodgroupsStyle as CircleLayerSpecification["paint"]}
-            />
-          </Source>
+        <Source
+          id="foodgroups-source"
+          type="vector"
+          url="mapbox://devseed.dlel0qkq"
+        >
+          <Layer
+            id="foodgroups-layer"
+            type="circle"
+            source-layer="foodgroup2max"
+            paint={foodgroupsStyle as CircleLayerSpecification["paint"]}
+          />
+        </Source>
 
-          <EdgeLayer />
+        <EdgeLayer />
 
-          {mapPopup && <MapPopup {...mapPopup} />}
-        </Map>
-      </div>
+        {mapPopup && <MapPopup {...mapPopup} />}
+      </Map>
     </div>
   );
 }

--- a/src/app/components/map/legend.tsx
+++ b/src/app/components/map/legend.tsx
@@ -1,7 +1,5 @@
-import { SIDEBAR_WIDTH } from "@/app/config";
 import { ArrowDown, ArrowUp } from "@phosphor-icons/react";
 import { useState } from "react";
-import { MachineContext } from "./state";
 
 interface ILegendItem {
   color: string;
@@ -19,15 +17,10 @@ function LegendItem({ color, label }: ILegendItem) {
 
 function Legend() {
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
-  const areaShowing = MachineContext.useSelector(
-    (s) => !!s.context.currentAreaId
-  );
-
-  const legendLeftOffset = areaShowing ? SIDEBAR_WIDTH : 0;
 
   return (
     <div
-      className={`absolute bottom-4 left-[calc((100vw-${legendLeftOffset}px)/2)] translate-x-[-50%] z-50 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]`}
+      className={`absolute left-1/2 translate-x-[-50%] bottom-4 z-50 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]`}
     >
       <button
         className={`flex gap-4 items-center px-4 py-2 w-[100%] bg-neutral-200/80 font-header text-xxs uppercase ${isExpanded ? "rounded-t" : "rounded"}`}

--- a/src/app/components/map/legend.tsx
+++ b/src/app/components/map/legend.tsx
@@ -1,5 +1,7 @@
+import { SIDEBAR_WIDTH } from "@/app/config";
 import { ArrowDown, ArrowUp } from "@phosphor-icons/react";
 import { useState } from "react";
+import { MachineContext } from "./state";
 
 interface ILegendItem {
   color: string;
@@ -17,9 +19,16 @@ function LegendItem({ color, label }: ILegendItem) {
 
 function Legend() {
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
+  const areaShowing = MachineContext.useSelector(
+    (s) => !!s.context.currentAreaId
+  );
+
+  const legendLeftOffset = areaShowing ? SIDEBAR_WIDTH : 0;
 
   return (
-    <div className="absolute bottom-4 left-[50%] translate-x-[-50%] z-50 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]">
+    <div
+      className={`absolute bottom-4 left-[calc((100vw-${legendLeftOffset}px)/2)] translate-x-[-50%] z-50 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]`}
+    >
       <button
         className={`flex gap-4 items-center px-4 py-2 w-[100%] bg-neutral-200/80 font-header text-xxs uppercase ${isExpanded ? "rounded-t" : "rounded"}`}
         onClick={() => setIsExpanded((prev) => !prev)}

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -9,6 +9,7 @@ import { IMapPopup } from "../../map-popup";
 import { EItemType } from "@/types/components";
 import { FetchAreaResponse } from "@/app/api/areas/[id]/route";
 import { worldViewState } from "..";
+import { SIDEBAR_WIDTH } from "@/app/config";
 
 export enum EViewType {
   world = "world",
@@ -290,7 +291,12 @@ export const globeViewMachine = createMachine(
             [bounds[2], bounds[3]],
           ],
           {
-            padding: 100,
+            padding: {
+              top: 100,
+              left: 100,
+              bottom: 100,
+              right: SIDEBAR_WIDTH + 100,
+            },
           }
         );
 

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -9,7 +9,6 @@ import { IMapPopup } from "../../map-popup";
 import { EItemType } from "@/types/components";
 import { FetchAreaResponse } from "@/app/api/areas/[id]/route";
 import { worldViewState } from "..";
-import { SIDEBAR_WIDTH } from "@/app/config";
 
 export enum EViewType {
   world = "world",
@@ -283,6 +282,8 @@ export const globeViewMachine = createMachine(
           return {};
         }
 
+        mapRef.resize();
+
         const bounds = bbox(currentArea.boundingBox);
 
         mapRef.fitBounds(
@@ -295,7 +296,7 @@ export const globeViewMachine = createMachine(
               top: 100,
               left: 100,
               bottom: 100,
-              right: SIDEBAR_WIDTH + 100,
+              right: 100,
             },
           }
         );
@@ -310,6 +311,8 @@ export const globeViewMachine = createMachine(
         if (!mapRef) {
           return {};
         }
+
+        mapRef.resize();
 
         mapRef.fitBounds(worldViewState.bounds);
 

--- a/src/app/config.ts
+++ b/src/app/config.ts
@@ -1,0 +1,1 @@
+export const SIDEBAR_WIDTH = 480;


### PR DESCRIPTION
Fixes #69 

- Adds `SIDEBAR_WIDTH` setting to configure the width of the sidebar
- Include the width in the fit-bounds padding