### PR TITLE
Add selected-area clip

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -37,7 +37,7 @@ const AreaPage = async ({
   const areaLabel = meta.iso3 ? `${area.name}, ${meta.iso3}` : area.name;
 
   return (
-    <div className={`w-[480px] bg-white`}>
+    <div className={`w-[600px] bg-white`}>
       <PageHeader title={areaLabel} itemType={EItemType.area} />
       <PageSection>
         <SectionHeader label="Food Produced" />

--- a/src/app/components/map/cartography.ts
+++ b/src/app/components/map/cartography.ts
@@ -1,25 +1,28 @@
-// Colors
-const AREA_HIGHLIGHT_COLOR = "rgba(250, 250, 249, 0.7)";
-const AREA_DEFAULT_COLOR = "rgba(250, 250, 249, 0.3)";
-const AREA_HIGHLIGHT_OUTLINE_COLOR = "rgba(0, 0, 0, 1)";
-const AREA_DEFAULT_OUTLINE_COLOR = "rgba(0, 0, 0, 0.3)";
+import {
+  CircleLayerSpecification,
+  FillLayerSpecification,
+  LineLayerSpecification,
+} from "mapbox-gl";
 
-export const areaStyle = {
-  "fill-color": [
-    "case",
-    ["boolean", ["feature-state", "hover"], false],
-    AREA_HIGHLIGHT_COLOR,
-    AREA_DEFAULT_COLOR,
-  ],
-  "fill-outline-color": [
+// Colors
+const AREA_HIGHLIGHT_OUTLINE_COLOR = "rgba(28, 25, 23, 0.6)";
+const AREA_DEFAULT_OUTLINE_COLOR = "rgba(28, 25, 23, 0.02)";
+
+export const areaStyle: FillLayerSpecification["paint"] = {
+  "fill-color": "transparent",
+};
+
+export const lineStyle: LineLayerSpecification["paint"] = {
+  "line-color": [
     "case",
     ["boolean", ["feature-state", "hover"], false],
     AREA_HIGHLIGHT_OUTLINE_COLOR,
     AREA_DEFAULT_OUTLINE_COLOR,
   ],
+  "line-width": ["interpolate", ["exponential", 1.99], ["zoom"], 3, 1, 7, 3],
 };
 
-export const foodgroupsStyle = {
+export const foodgroupsStyle: CircleLayerSpecification["paint"] = {
   "circle-emissive-strength": 1,
   "circle-color": [
     "match",

--- a/src/app/components/map/cartography.ts
+++ b/src/app/components/map/cartography.ts
@@ -8,14 +8,25 @@ import {
 const AREA_HIGHLIGHT_OUTLINE_COLOR = "rgba(28, 25, 23, 0.6)";
 const AREA_DEFAULT_OUTLINE_COLOR = "rgba(28, 25, 23, 0.02)";
 
-export const areaStyle: FillLayerSpecification["paint"] = {
+export const areaDefaultStyle: FillLayerSpecification["paint"] = {
   "fill-color": "transparent",
+};
+
+export const areaStyle: FillLayerSpecification["paint"] = {
+  "fill-color": [
+    "case",
+    ["boolean", ["feature-state", "selected"], false],
+    "transparent",
+    "rgba(255,255,255,0.6)",
+  ],
 };
 
 export const lineStyle: LineLayerSpecification["paint"] = {
   "line-color": [
     "case",
     ["boolean", ["feature-state", "hover"], false],
+    AREA_HIGHLIGHT_OUTLINE_COLOR,
+    ["boolean", ["feature-state", "selected"], false],
     AREA_HIGHLIGHT_OUTLINE_COLOR,
     AREA_DEFAULT_OUTLINE_COLOR,
   ],

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -8,7 +8,6 @@ import Map, {
   MapRef,
   LngLatBoundsLike,
 } from "react-map-gl";
-import { CircleLayerSpecification, FillLayerSpecification } from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 
 import MapPopup from "@/app/components/map-popup";
@@ -16,7 +15,7 @@ import MapPopup from "@/app/components/map-popup";
 import { MachineContext, MachineProvider } from "./state";
 import EdgeLayer from "./layers/edges";
 import Legend from "./legend";
-import { areaStyle, foodgroupsStyle } from "./cartography";
+import { areaStyle, foodgroupsStyle, lineStyle } from "./cartography";
 
 // Environment variables used in this component
 const appUrl = process.env.NEXT_PUBLIC_APP_URL;
@@ -126,13 +125,13 @@ function GlobeInner() {
               id="area-outline"
               type="line"
               source-layer="default"
-              paint={{ "line-color": "#000", "line-width": 0.2 }}
+              paint={lineStyle}
             />
             <Layer
               id="area-clickable-polygon"
               type="fill"
               source-layer="default"
-              paint={areaStyle as FillLayerSpecification["paint"]}
+              paint={areaStyle}
             />
           </Source>
 
@@ -145,7 +144,7 @@ function GlobeInner() {
               id="foodgroups-layer"
               type="circle"
               source-layer="foodgroup2max"
-              paint={foodgroupsStyle as CircleLayerSpecification["paint"]}
+              paint={foodgroupsStyle}
             />
           </Source>
 

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -15,7 +15,12 @@ import MapPopup from "@/app/components/map-popup";
 import { MachineContext, MachineProvider } from "./state";
 import EdgeLayer from "./layers/edges";
 import Legend from "./legend";
-import { areaStyle, foodgroupsStyle, lineStyle } from "./cartography";
+import {
+  areaDefaultStyle,
+  areaStyle,
+  foodgroupsStyle,
+  lineStyle,
+} from "./cartography";
 
 // Environment variables used in this component
 const appUrl = process.env.NEXT_PUBLIC_APP_URL;
@@ -49,6 +54,9 @@ function GlobeInner() {
   );
   const mapPopup = MachineContext.useSelector(
     (state) => state.context.mapPopup
+  );
+  const areaSelected = MachineContext.useSelector(
+    (state) => !!state.context.currentArea
   );
 
   const handleMouseMove = useCallback((event: MapMouseEvent) => {
@@ -117,25 +125,6 @@ function GlobeInner() {
           mapStyle={mapboxStyleUrl}
         >
           <Source
-            id="area-tiles"
-            type="vector"
-            tiles={[`${appUrl}/api/tiles/areas/{z}/{x}/{y}`]}
-          >
-            <Layer
-              id="area-outline"
-              type="line"
-              source-layer="default"
-              paint={lineStyle}
-            />
-            <Layer
-              id="area-clickable-polygon"
-              type="fill"
-              source-layer="default"
-              paint={areaStyle}
-            />
-          </Source>
-
-          <Source
             id="foodgroups-source"
             type="vector"
             url="mapbox://devseed.dlel0qkq"
@@ -145,6 +134,25 @@ function GlobeInner() {
               type="circle"
               source-layer="foodgroup2max"
               paint={foodgroupsStyle}
+            />
+          </Source>
+
+          <Source
+            id="area-tiles"
+            type="vector"
+            tiles={[`${appUrl}/api/tiles/areas/{z}/{x}/{y}`]}
+          >
+            <Layer
+              id="area-clickable-polygon"
+              type="fill"
+              source-layer="default"
+              paint={areaSelected ? areaStyle : areaDefaultStyle}
+            />
+            <Layer
+              id="area-outline"
+              type="line"
+              source-layer="default"
+              paint={lineStyle}
             />
           </Source>
 

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -30,7 +30,7 @@ interface StateContext {
 
 export const globeViewMachine = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggIZlicKxgUYAMZsA2gAYAuolAAHNLFxtcaFrJAAPRADYATET16AHAGYA7OZPmAnHp06JAVgA0IAJ6IAtAEYnB0x0fYwAWQNM9cwljPQBfWLdUTBw6EnJKGjpGZnYEAFtOOXy0AFcBPLRmSRkkEAUlFTUNbQQ9JxsiGydnGwkQ8x0QoJ83TwRfHyIHPR87YKCTMxD4xPQsPEI0iipaQmzWDhKKBAOwMmqNeuVVdVqWoKIJHz0LV-9LK1HEU3aibuMdKZTBIJDpuj4+isQEl1qkCkUKiV2LgWFB9rl4cUkeJpJdFNcmndvIFJsDejobMYnMYaTovghwVMnCE+uYWf0nFYoTCUptuLwEAAzMBsYQACxRaIgajARBR1DQAGtZTyNsR+XxhaKJaiEPK0MJOI0WNULrUrsbmogfEMOsYJJSLOZjD5zPSuqYiCFjOYnM9Aj7maZuWteeqeHxdgwmAcuBGEMIhNwzfJ8ZaiQggp7HBCnE7zLM-PSBhJDOZTD5whZIj4fCHkmqiBrMnsY7lmwIhKIU3U0zcrQhbJMnE5HAMWcCzMZ6QDJmY9M4lqYbKYQk567C+fGo+iOJjEeVKmAexb+xnIh1Kw6Kf4bcY7PSIRYiK6qWD2vfOeYN2Gm9usm2hzHKc5y4uafaEqALReAMRADDYIRGDYvq9FY04eIgs5EPOEIFguvpxAk0Kho2cicDACDoJwED0CeEG3FBmEPCCoKUiuiFPKY9JDKSgyAiOVhdDo5Y-qR5FgJRaDUbRPg1KmDRnoxCDPA6L5RD4Og0vabJhPSwkGNS7TRCOdj3oRqwNqkZEUYiyKoruCDWRJtk4nJvYKZBWjEoCcEOrYpgAr0LI2PSLw6IYfQstSUTMjSyxQiwaAQHAGiqnQeIeQxXnjCEta+chK6BX0Dr0l4LwdMyNi1ghyEOKCwZEWlmykNsLYEBlBJZS0IQdIMuEROW9hriMGHKRp2GjmYlIum0PUNRZm7EPupR2VAHXpkpXirsYhiBFEDrtEMzohPSy7hVVCzekhzw2qJqTNlq4qSutinZTa9hwWEVJhEd7R6Kd1J-FVMTLiEYP2OZxGWVuApRi9nktC85hTK6GnCQMgTROhYwAqWVX+D1JjBO0Oh3ZsTmSdR8NdcSFZTMh-gAi8YOjnpUSPHhLK2N6HJk8QFMuc94GZQOW3dFMFhhAFAWVt6j4si+NgOBSILUvYXTxPEQA */
+    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EAFgDsAJiIBOXVICM+gMwAOKSf1nd1gDQgAnogC0h3UVsAVl0TKSlAizMANkMLKKiAXwT3VEwcOhJySho6RmZ2Lj4BYTAhNmk5JBBFZVV1TR0EKN0LIil9dqj2m0NmwPcvBG8LSyJAsJs7QMMnYJMklPQsPEJMiipaQjzWDkEKBB2wMgrNGpU1DSrGqNbLQ2sbG2n9F8MBxGtAkzGpWyjraxhKLjEa6BYgVLLDI8fhiQTsXAsKDbAow4rsE5VM51S6gRreaw3IiA0JRExBWyUqLvBAgojA8wGRn6QJGcGQ9KrbhkMDcBAAMzAbAAxgALRHIiDqMBERHUNAAaxlHJWxG5vIFQrFEoQcrQwu4OIqmIUSnO9SuiAsujJAQctge+lsVhpJkC1iIulsLIs9yi3uC1nZS05ap5fM2DCYOwQ6r5wpQvOOslOZpxDUQNw9XRG7pe+kiFn6nkQ+i6RBm1gshIBRgLFmDaVVRDjOS20dRRThIjEkhTWLTFwzCFznrsvQsFkpRcCQRpoP0xNZ8VnhhMhnCYOSEJDzdbkZRHDR3dKgnK-dNtSHloQLKkASzJnXcUnJmpJZHUgMS7LwNsa43YJGyhLlwzbKN8l2fZDmTSpL3NXFtB8MsiDLMxDDXFlQiMWwaT+VoHVidpfXaaZgNDIheG4GAEHQbgIHoE1qkHC08UQfC2iBckTGsXQN2rGkbVaQkbU+Vk10CKIbHI5sqJouiGIkCw4OYq9WKQkcN2+KxLH9Sl2l0FwaSk4xZy+X5Ai+QxbHXGSMjksB0VUJFDwQBynKY7FrzYoYa1QhwnDsMkvwcGk-QrL9zFnDpgkpLdtxYNAIDgTQVToVM1MQ-EWlaDpHB4v5QnMEwaWGGzOPaAEghmN1Ajs1ZSHWcCMoQ4cQnpFpKsrXpdAiec4gCSSHXJZ1DDmINtzS1ZjyEBEkRa9MbwJL0K0JDoHC+G0nV0GlrDfUwXz8f8119a16rDDVBRFcV5oHTLh2tXpUJcIIXC2qzdtnMYTCne5nD4mJzpbMDIwW7yNPuRcbgLeIXn+LpKTw8sfumEJrKnL5Ekm3d7OoxyFLB9T8QBVoyRZayYl43r30GKT72Ivx2jMWwDDq7Gm1xmi4TmqBCaynxPnvf59BcOw7GrL153MIhIniYLwn-Mk2aSIA */
     id: "globeView",
 
     types: {
@@ -55,12 +55,6 @@ export const globeViewMachine = createMachine(
     states: {
       "world:view": {
         on: {
-          "event:area:select": {
-            target: "area:fetching",
-            actions: "action:setCurrentAreaId",
-            reenter: true,
-          },
-
           "event:map:mousemove": {
             target: "world:view",
             actions: "action:setHighlightedArea",
@@ -76,7 +70,7 @@ export const globeViewMachine = createMachine(
             reenter: true,
             actions: [
               {
-                type: "action:parseUrl",
+                type: "action:WorldViewUrlChange",
                 params: ({ event }) => ({
                   pathname: event.pathname,
                 }),
@@ -119,12 +113,6 @@ export const globeViewMachine = createMachine(
             reenter: true,
           },
 
-          "event:area:select": {
-            target: "area:fetching",
-            reenter: true,
-            actions: "action:setCurrentAreaId",
-          },
-
           "event:map:mousemove": {
             target: "area:view",
             actions: "action:setHighlightedArea",
@@ -138,12 +126,14 @@ export const globeViewMachine = createMachine(
           "event:url:enter": {
             target: "page:load",
             reenter: true,
-            actions: {
-              type: "action:parseUrl",
-              params: ({ event }) => ({
-                pathname: event.pathname,
-              }),
-            },
+            actions: [
+              {
+                type: "action:AreaViewUrlChange",
+                params: ({ event }) => ({
+                  pathname: event.pathname,
+                }),
+              },
+            ],
           },
         },
 
@@ -170,7 +160,7 @@ export const globeViewMachine = createMachine(
             reenter: true,
             actions: [
               {
-                type: "action:parseUrl",
+                type: "action:WorldViewUrlChange",
                 params: ({ event }) => ({
                   pathname: event.pathname,
                 }),
@@ -185,10 +175,9 @@ export const globeViewMachine = createMachine(
   },
   {
     actions: {
-      "action:parseUrl": assign((_, params: { pathname: string }) => {
+      "action:WorldViewUrlChange": assign((_, params: { pathname: string }) => {
         if (params.pathname.startsWith("/area/")) {
           const [, , areaId] = params.pathname.split("/");
-
           return {
             viewType: EViewType.area,
             currentAreaId: areaId,
@@ -203,6 +192,39 @@ export const globeViewMachine = createMachine(
           currentArea: null,
         };
       }),
+      "action:AreaViewUrlChange": assign(
+        ({ context }, params: { pathname: string }) => {
+          const [, , areaId] = params.pathname.split("/");
+
+          const { mapRef, currentArea } = context;
+
+          if (mapRef && currentArea) {
+            const features = mapRef.querySourceFeatures("area-tiles", {
+              filter: ["==", "id", currentArea.id],
+              sourceLayer: "default",
+            });
+
+            for (let i = 0, len = features.length; i < len; i++) {
+              const feature = features[i];
+              if (feature.id) {
+                mapRef.setFeatureState(
+                  {
+                    source: "area-tiles",
+                    sourceLayer: "default",
+                    id: feature.id,
+                  },
+                  { selected: false }
+                );
+              }
+            }
+          }
+
+          return {
+            viewType: EViewType.area,
+            currentAreaId: areaId,
+          };
+        }
+      ),
       "action:setMapRef": assign(({ event }) => {
         assertEvent(event, "event:map:mount");
 
@@ -268,8 +290,25 @@ export const globeViewMachine = createMachine(
           mapPopup: null,
         };
       }),
-      "action:setCurrentArea": assign(({ event }) => {
+      "action:setCurrentArea": assign(({ event, context }) => {
         assertEvent(event, "xstate.done.actor.0.globeView.area:fetching");
+        const { mapRef } = context;
+
+        const features = mapRef?.querySourceFeatures("area-tiles", {
+          filter: ["==", "id", event.output.id],
+          sourceLayer: "default",
+        });
+        const feature = features && features[0];
+        if (feature && feature.id) {
+          mapRef?.setFeatureState(
+            {
+              source: "area-tiles",
+              sourceLayer: "default",
+              id: feature.id,
+            },
+            { selected: true }
+          );
+        }
 
         return {
           currentArea: event.output,
@@ -308,23 +347,6 @@ export const globeViewMachine = createMachine(
         mapRef.fitBounds(worldViewState.bounds);
 
         return {};
-      }),
-      "action:setCurrentAreaId": assign(({ event, context }) => {
-        assertEvent(event, "event:area:select");
-
-        const { mapRef } = context;
-        const features = mapRef?.querySourceFeatures("area-tiles", {
-          filter: ["id", event.areaId],
-          sourceLayer: "area-clickable-polygon",
-        });
-
-        if (features) {
-          mapRef?.setFeatureState(features[0], { selected: true });
-        }
-
-        return {
-          currentAreaId: event.areaId,
-        };
       }),
       "action:area:clear": assign({
         currentAreaId: null,

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -128,13 +128,13 @@ export const globeViewMachine = createMachine(
             reenter: true,
             actions: [
               {
+                type: "action:resetAreaHighlight",
+              },
+              {
                 type: "action:parseUrl",
                 params: ({ event }) => ({
                   pathname: event.pathname,
                 }),
-              },
-              {
-                type: "action:resetAreaHighlight",
               },
             ],
           },

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -309,8 +309,19 @@ export const globeViewMachine = createMachine(
 
         return {};
       }),
-      "action:setCurrentAreaId": assign(({ event }) => {
+      "action:setCurrentAreaId": assign(({ event, context }) => {
         assertEvent(event, "event:area:select");
+
+        const { mapRef } = context;
+        const features = mapRef?.querySourceFeatures("area-tiles", {
+          filter: ["id", event.areaId],
+          sourceLayer: "area-clickable-polygon",
+        });
+
+        if (features) {
+          mapRef?.setFeatureState(features[0], { selected: true });
+        }
+
         return {
           currentAreaId: event.areaId,
         };

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -3,8 +3,18 @@ import { GeoJSONFeature } from "mapbox-gl";
 import { IMapPopup } from "@/app/components/map-popup";
 import { EViewType } from "../machine";
 
-interface ActionParseUrl {
-  type: "action:parseUrl";
+interface ActionWorldViewUrlChange {
+  type: "action:WorldViewUrlChange";
+  params: {
+    pathname: string;
+  };
+  viewType: EViewType | null;
+  currentAreaId?: string | null;
+  currentArea?: GeoJSON.Feature | null;
+}
+
+interface ActionAreaViewUrlChange {
+  type: "action:AreaViewUrlChange";
   params: {
     pathname: string;
   };
@@ -49,7 +59,8 @@ interface ActionAreaClear {
 }
 
 export type StateActions =
-  | ActionParseUrl
+  | ActionWorldViewUrlChange
+  | ActionAreaViewUrlChange
   | ActionSetMapRef
   | ActionSetHighlightedArea
   | ActionClearHighlightedArea

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -3,8 +3,8 @@ import { GeoJSONFeature } from "mapbox-gl";
 import { IMapPopup } from "@/app/components/map-popup";
 import { EViewType } from "../machine";
 
-interface ActionWorldViewUrlChange {
-  type: "action:WorldViewUrlChange";
+interface ActionParseUrl {
+  type: "action:parseUrl";
   params: {
     pathname: string;
   };
@@ -13,14 +13,8 @@ interface ActionWorldViewUrlChange {
   currentArea?: GeoJSON.Feature | null;
 }
 
-interface ActionAreaViewUrlChange {
-  type: "action:AreaViewUrlChange";
-  params: {
-    pathname: string;
-  };
-  viewType: EViewType | null;
-  currentAreaId?: string | null;
-  currentArea?: GeoJSON.Feature | null;
+interface ResetAreaHighlight {
+  type: "action:resetAreaHighlight";
 }
 
 interface ActionSetMapRef {
@@ -59,8 +53,8 @@ interface ActionAreaClear {
 }
 
 export type StateActions =
-  | ActionWorldViewUrlChange
-  | ActionAreaViewUrlChange
+  | ActionParseUrl
+  | ResetAreaHighlight
   | ActionSetMapRef
   | ActionSetHighlightedArea
   | ActionClearHighlightedArea

--- a/src/app/components/map/state/types/events.ts
+++ b/src/app/components/map/state/types/events.ts
@@ -25,11 +25,6 @@ interface EventMapMouseOut {
   type: "event:map:mouseout";
 }
 
-interface EventAreaSelect {
-  type: "event:area:select";
-  areaId: string;
-}
-
 interface EventFetchAreaDone {
   type: "xstate.done.actor.0.globeView.area:fetching";
   input: {
@@ -47,7 +42,6 @@ export type StateEvents =
   | EventUrlEnter
   | EventMapMount
   | EventMapMouseMove
-  | EventAreaSelect
   | EventFetchAreaDone
   | EventAreaClear
   | EventMapMouseOut;


### PR DESCRIPTION
Contributes to https://github.com/earth-genome/foodtwin-global-app/issues/56

- Remove the area-outline layers as the outline is duplicated in the areaStyle
- Update the area style:
  - Made the outlines lighter
  - Removed the highlight-area background
  - Add stronger highlight-area outline
- Add new action `action:AreaViewUrlChange`, which handles deleting the current selected-area feature state
- Extend action `action:setCurrentArea` to set the selected-area feature state