### PR TITLE
Add transportation chart to project page

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -131,102 +131,104 @@ const AreaPage = async ({
   const areaLabel = meta.iso3 ? `${area.name}, ${meta.iso3}` : area.name;
 
   return (
-    <div className={`w-[600px] bg-white`}>
+    <div className={`w-[600px] bg-white h-screen grid grid-rows-[max-content_1fr]`}>
       <PageHeader title={areaLabel} itemType={EItemType.area} />
-      <PageSection>
-        <SectionHeader label="Food Produced" />
-        <MetricRow>
-          <Metric
-            label="Total production"
-            value={totalFlow ?? undefined}
-            formatType="weight"
-            decimalPlaces={0}
-          />
-          <Metric
-            label="Agriculture sector in GDP"
-            value={meta.aggdp_2010}
-            formatType="metric"
-            decimalPlaces={3}
-            unit="2010 USD$"
-          />
-          <Metric
-            label="GDP per capita"
-            value={meta.gdppc}
-            formatType="metric"
-            decimalPlaces={1}
-            unit="2011 USD$"
-          />
-        </MetricRow>
-        <MetricRow>
-          <Metric
-            label="Total population"
-            value={meta.totalpop}
-            formatType="metric"
-            decimalPlaces={1}
-          />
-          <Metric
-            label="Human Development Index"
-            value={meta.hdi}
-            formatType="metric"
-            decimalPlaces={3}
-          />
-        </MetricRow>
+      <div className="overflow-y-auto">
+        <PageSection>
+          <SectionHeader label="Food Produced" />
+          <MetricRow>
+            <Metric
+              label="Total production"
+              value={totalFlow ?? undefined}
+              formatType="weight"
+              decimalPlaces={0}
+            />
+            <Metric
+              label="Agriculture sector in GDP"
+              value={meta.aggdp_2010}
+              formatType="metric"
+              decimalPlaces={3}
+              unit="2010 USD$"
+            />
+            <Metric
+              label="GDP per capita"
+              value={meta.gdppc}
+              formatType="metric"
+              decimalPlaces={1}
+              unit="2011 USD$"
+            />
+          </MetricRow>
+          <MetricRow>
+            <Metric
+              label="Total population"
+              value={meta.totalpop}
+              formatType="metric"
+              decimalPlaces={1}
+            />
+            <Metric
+              label="Human Development Index"
+              value={meta.hdi}
+              formatType="metric"
+              decimalPlaces={3}
+            />
+          </MetricRow>
 
-        <ListBars
-          showPercentage
-          formatType="weight"
-          data={Object.values(foodGroupAgg).map(
-            ({ name, sum }) => ({
-              label: name,
-              value: sum,
-            })
-          )}
-        />
-      </PageSection>
-      <PageSection>
-        <SectionHeader label="Food Transportation" />
-        <MetricRow>
-          <Metric
-            label="Exported outside the region"
-            value={totalExport}
+          <ListBars
+            showPercentage
             formatType="weight"
-            decimalPlaces={0}
-          />
-          <Metric
-            label="Suplied to the region"
-            value={(inBoundFlows as ImportSum[])[0].sum}
-            formatType="weight"
-            decimalPlaces={0}
-          />
-        </MetricRow>
-        <Sankey
-          width={480}
-          height={600}
-          data={{
-            nodes: [
-              { id: area.id, label: area.name, type: EItemType["area"] },
-              { id: "other", label: "Other", type: EItemType["node"] },
-              ...(outboundFlows as ExportFlow[]).map(({ toAreaId, name, value }) => ({
-                id: toAreaId,
+            data={Object.values(foodGroupAgg).map(
+              ({ name, sum }) => ({
                 label: name,
-                type: EItemType["node"]
-              }))
-            ],
-            links: [
-                ...(outboundFlows as ExportFlow[]).slice(0, 10).map(({ toAreaId, value }) => ({
-                  source: area.id,
-                  target: toAreaId,
-                  value
-                })),
-                {
-                  source: area.id,
-                  target: "other",
-                  value: (outboundFlows as ExportFlow[]).slice(10).reduce((sum, { value }) => sum + value, 0),
-                }
-            ]
-          }}
-        />
-      </PageSection>
+                value: sum,
+              })
+            )}
+          />
+        </PageSection>
+        <PageSection>
+          <SectionHeader label="Food Transportation" />
+          <MetricRow>
+            <Metric
+              label="Exported outside the region"
+              value={totalExport}
+              formatType="weight"
+              decimalPlaces={0}
+            />
+            <Metric
+              label="Suplied to the region"
+              value={(inBoundFlows as ImportSum[])[0].sum}
+              formatType="weight"
+              decimalPlaces={0}
+            />
+          </MetricRow>
+          <Sankey
+            width={400}
+            height={600}
+            data={{
+              nodes: [
+                { id: area.id, label: area.name, type: EItemType["area"] },
+                { id: "other", label: "Other", type: EItemType["node"] },
+                ...(outboundFlows as ExportFlow[]).map(({ toAreaId, name, value }) => ({
+                  id: toAreaId,
+                  label: name,
+                  type: EItemType["node"]
+                }))
+              ],
+              links: [
+                  ...(outboundFlows as ExportFlow[]).slice(0, 10).map(({ toAreaId, value }) => ({
+                    source: area.id,
+                    target: toAreaId,
+                    value
+                  })),
+                  {
+                    source: area.id,
+                    target: "other",
+                    value: (outboundFlows as ExportFlow[]).slice(10).reduce((sum, { value }) => sum + value, 0),
+                  }
+              ]
+            }}
+          />
+        </PageSection>
+      </div>
     </div>
   );
 };

--- a/src/app/components/charts/sankey.tsx
+++ b/src/app/components/charts/sankey.tsx
@@ -123,6 +123,7 @@ function Sankey({ height, width, data }: ISankey) {
       .attr("d", sankeyLinkHorizontal())
       .attr("stroke", "#E7E5E4")
       .attr("opacity", 0.25)
+      .attr("fill", "none")
       .attr("stroke-width", (d) => Math.max(1, d.width || 0))
       .on("mouseover mousemove", (e, d) => {
         const { pageX, pageY } = e;

--- a/src/app/sandbox/components/page.tsx
+++ b/src/app/sandbox/components/page.tsx
@@ -117,6 +117,7 @@ export default function Components() {
         <Tabs>
           <Tab title="Food groups">
             <ListBars
+              formatType="weight"
               showPercentage
               unit="million MMt"
               data={[
@@ -135,6 +136,7 @@ export default function Components() {
           </Tab>
           <Tab title="Nutritional value">
             <ListBars
+              formatType="weight"
               unit="Millions people’s needs"
               data={[
                 {


### PR DESCRIPTION
Adds the food-transportation indicators and sankey chart to project page

<img width="437" alt="Screenshot 2024-10-22 at 17 06 47" src="https://github.com/user-attachments/assets/e24d6421-1fe6-46bb-9f45-c8e061fa6cf3">

- Adds two DB queries:
  - The sums of all imports
  - Detailed information for each export flow. From the `FlowSegment` table, we joint the `Flow` data, so we can get to the value, and the `Node` data so we can get the target node information. Currently, we're using the `toAreaId` of the whole flow as the target area, but this should be changed once we have the `toAreaId` for each `FlowSegment`
- Adds Sankey chart. We're showing the top 10 export flows by value and group all other flows under "Other"
- fix: Removes the fill from the Sankey links
- fix: Handling the overflow in the side bar. 