### PR TITLE
feat: Add food-produced to transport transition

### DIFF
--- a/src/app/components/map/layers/area.tsx
+++ b/src/app/components/map/layers/area.tsx
@@ -27,6 +27,8 @@ export const lineStyle: LineLayerSpecification["paint"] = {
     AREA_HIGHLIGHT_OUTLINE_COLOR,
     ["boolean", ["feature-state", "selected"], false],
     AREA_HIGHLIGHT_OUTLINE_COLOR,
+    ["boolean", ["feature-state", "target"], false],
+    AREA_HIGHLIGHT_OUTLINE_COLOR,
     AREA_DEFAULT_OUTLINE_COLOR,
   ],
   "line-width": ["interpolate", ["exponential", 1.99], ["zoom"], 3, 1, 7, 3],

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -45,9 +45,6 @@ interface ActionSetCurrentArea {
   area: GeoJSON.Feature;
 }
 
-interface ActionSetAreaMapView {
-  type: "action:setAreaMapView";
-}
 interface ActionSetProductionAreaView {
   type: "action:setProductionAreaView";
 }
@@ -79,6 +76,5 @@ export type StateActions =
   | ActionSetProductionAreaView
   | ActionSetTransportationAreaView
   | ActionSetImpactAreaView
-  | ActionSetAreaMapView
   | ActionSetWorldMapView
   | ActionAreaClear;

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -1,0 +1,17 @@
+import { BBox } from "geojson";
+
+export function combineBboxes(bboxes: BBox[]): BBox {
+  let minLeft: number = 180;
+  let minBottom: number = 90;
+  let maxRight: number = -180;
+  let maxTop: number = -90;
+
+  bboxes.forEach(([left, bottom, right, top]) => {
+    if (left < minLeft) minLeft = left;
+    if (bottom < minBottom) minBottom = bottom;
+    if (right > maxRight) maxRight = right;
+    if (top > maxTop) maxTop = top;
+  });
+
+  return [minLeft, minBottom, maxRight, maxTop];
+}


### PR DESCRIPTION
Adds the map transitions between food produced and transportation states

- Extend the `/api/areas/[id]` API, so it returns a GeoJSON for the destination areas of flows from the given area.
- Extend `action:setProductionAreaView` to remove the highlights from destination areas and zoom to the area bounding box
- Extend `action:setTransportationAreaView` to add the highlights of destination areas and zoom to the bounding box of the selected area and destination areas
- Remove `action:setAreaMapView` because the transition is now duplicated in `action:setProductionAreaView`