### PR TITLE
Enhance transportation view (based on #84)

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -6,7 +6,7 @@ import ScrollTracker from "./scroll-tracker";
 import { PageSection, SectionHeader } from "@/app/components/page-section";
 import { Metric, MetricRow } from "@/app/components/metric";
 import { AreaMeta } from "../../../../../prisma/seed/nodes";
-import { FoodGroup, Prisma } from "@prisma/client";
+import { FoodGroup } from "@prisma/client";
 import { ListBars, Sankey } from "@/app/components/charts";
 import { formatKeyIndicator } from "@/utils/numbers";
 import { EAreaViewType } from "@/app/components/map/state/machine";
@@ -16,12 +16,10 @@ interface IFoodGroupAgg extends FoodGroup {
   values: {
     _sum: { value: number | null };
     foodGroupId: number;
-  }[]
+  }[];
 }
 
-interface IFoodGroupAggObj {
-  [key: string]: IFoodGroupAgg
-}
+type IFoodGroupAggObj = Record<string, IFoodGroupAgg>;
 
 interface ImportSum {
   sum: number;
@@ -37,12 +35,12 @@ interface ExportFlow {
 
 function findParent(id: number, foodGroups: FoodGroup[]) {
   const g = foodGroups.find((group) => id === group.id);
-  if (!g!.parentId) {
+  if (!g?.parentId) {
     return g;
   } else {
-    return findParent(g!.parentId, foodGroups);
+    return findParent(g?.parentId, foodGroups);
   }
-};
+}
 
 const AreaPage = async ({
   params,
@@ -61,79 +59,85 @@ const AreaPage = async ({
     return redirect("/not-found");
   }
 
-  const [
-    foodGroupExports,
-    foodGroups,
-    inBoundFlows,
-    outboundFlows,
-  ] = await Promise.all([
-    prisma.flow.groupBy({
-      where: {
-        fromAreaId: area.id,
-      },
-      by: ['foodGroupId'],
-      _sum: {
-        value: true,
-      },
-    }),
-    prisma.foodGroup.findMany(),
-    prisma.$queryRawUnsafe(`
+  const [foodGroupExports, foodGroups, inBoundFlows, outboundFlows] =
+    await Promise.all([
+      prisma.flow.groupBy({
+        where: {
+          fromAreaId: area.id,
+        },
+        by: ["foodGroupId"],
+        _sum: {
+          value: true,
+        },
+      }),
+      prisma.foodGroup.findMany(),
+      prisma.$queryRawUnsafe(`
       SELECT sum(value)
         FROM "FlowSegment"
         LEFT JOIN "Flow" ON "FlowSegment"."flowId" = "Flow"."id"
         WHERE "flowId" like '%-${area.id}-%';
     `),
-    prisma.$queryRawUnsafe(
-      `SELECT "mode", sum("value") as value, "toAreaId", "Node"."name", "Node"."type"
+      prisma.$queryRawUnsafe(
+        `SELECT "mode", sum("value") as value, "toAreaId", "Node"."name", "Node"."type"
         FROM "FlowSegment"
         LEFT JOIN "Flow" ON "FlowSegment"."flowId" = "Flow"."id"
         LEFT JOIN "Node" ON "Flow"."toAreaId" = "Node"."id"
         WHERE "flowId" LIKE '${area.id}-%' AND "order" = 1
         GROUP BY "toAreaId", "mode", "Node"."name", "Node"."type"
         ORDER BY value DESC;
-    `),
-  ]);
+    `
+      ),
+    ]);
 
-  const foodGroupAgg = foodGroupExports.reduce((agg: IFoodGroupAggObj, group): IFoodGroupAggObj => {
-    const parent = findParent(group.foodGroupId, foodGroups);
+  const foodGroupAgg = foodGroupExports.reduce(
+    (agg: IFoodGroupAggObj, group): IFoodGroupAggObj => {
+      const parent = findParent(group.foodGroupId, foodGroups);
 
-    if (!parent) return agg;
+      if (!parent) return agg;
 
-    const parentId = parent.id.toString();
+      const parentId = parent.id.toString();
 
-    if (Object.keys(agg).includes(parentId)) {
-      return {
-        ...agg,
-        [parentId]: {
-          ...parent,
-          sum: group._sum.value ? agg[parentId].sum + group._sum.value : agg[parentId].sum,
-          values: [
-            ...agg[parentId].values,
-            group
-          ]
-        }
+      if (Object.keys(agg).includes(parentId)) {
+        return {
+          ...agg,
+          [parentId]: {
+            ...parent,
+            sum: group._sum.value
+              ? agg[parentId].sum + group._sum.value
+              : agg[parentId].sum,
+            values: [...agg[parentId].values, group],
+          },
+        };
+      } else {
+        return {
+          ...agg,
+          [parentId]: {
+            ...parent,
+            sum: group._sum.value || 0,
+            values: [group],
+          },
+        };
       }
-    } else {
-      return {
-        ...agg,
-        [parentId]: {
-          ...parent,
-          sum: group._sum.value || 0,
-          values: [
-            group
-          ]
-        }
-      }
-    }
-  }, {});
+    },
+    {}
+  );
 
-  const totalFlow = foodGroupExports.reduce((partialSum, { _sum }) => _sum.value ? partialSum + _sum.value : partialSum, 0);
-  const totalExport = (outboundFlows as ExportFlow[]).reduce((partialSum, { value }) => partialSum + value, 0);
+  const totalFlow = foodGroupExports.reduce(
+    (partialSum, { _sum }) =>
+      _sum.value ? partialSum + _sum.value : partialSum,
+    0
+  );
+  const totalExport = (outboundFlows as ExportFlow[]).reduce(
+    (partialSum, { value }) => partialSum + value,
+    0
+  );
   const meta = area.meta as AreaMeta;
   const areaLabel = meta.iso3 ? `${area.name}, ${meta.iso3}` : area.name;
 
   return (
-    <div className={`w-[600px] bg-white h-screen grid grid-rows-[max-content_1fr]`}>
+    <div
+      className={`w-[600px] bg-white h-screen grid grid-rows-[max-content_1fr]`}
+    >
       <PageHeader title={areaLabel} itemType={EItemType.area} />
       <ScrollTracker>
         <PageSection id={EAreaViewType.production}>
@@ -178,12 +182,10 @@ const AreaPage = async ({
           <ListBars
             showPercentage
             formatType="weight"
-            data={Object.values(foodGroupAgg).map(
-              ({ name, sum }) => ({
-                label: name,
-                value: sum,
-              })
-            )}
+            data={Object.values(foodGroupAgg).map(({ name, sum }) => ({
+              label: name,
+              value: sum,
+            }))}
           />
         </PageSection>
         <PageSection id={EAreaViewType.transportation}>
@@ -209,28 +211,36 @@ const AreaPage = async ({
               nodes: [
                 { id: area.id, label: area.name, type: EItemType["area"] },
                 { id: "other", label: "Other", type: EItemType["node"] },
-                ...(outboundFlows as ExportFlow[]).map(({ toAreaId, name, value }) => ({
-                  id: toAreaId,
-                  label: name,
-                  type: EItemType["node"]
-                }))
+                ...(outboundFlows as ExportFlow[]).map(
+                  ({ toAreaId, name }) => ({
+                    id: toAreaId,
+                    label: name,
+                    type: EItemType["node"],
+                  })
+                ),
               ],
               links: [
-                  ...(outboundFlows as ExportFlow[]).slice(0, 10).map(({ toAreaId, value }) => ({
+                ...(outboundFlows as ExportFlow[])
+                  .slice(0, 10)
+                  .map(({ toAreaId, value }) => ({
                     source: area.id,
                     target: toAreaId,
                     value,
-                    popupData: [{
-                      label: "Volume",
-                      value: formatKeyIndicator(value, "weight", 0),
-                    }]
+                    popupData: [
+                      {
+                        label: "Volume",
+                        value: formatKeyIndicator(value, "weight", 0),
+                      },
+                    ],
                   })),
-                  {
-                    source: area.id,
-                    target: "other",
-                    value: (outboundFlows as ExportFlow[]).slice(10).reduce((sum, { value }) => sum + value, 0),
-                  }
-              ]
+                {
+                  source: area.id,
+                  target: "other",
+                  value: (outboundFlows as ExportFlow[])
+                    .slice(10)
+                    .reduce((sum, { value }) => sum + value, 0),
+                },
+              ],
             }}
           />
         </PageSection>

--- a/src/app/api/areas/[id]/route.ts
+++ b/src/app/api/areas/[id]/route.ts
@@ -14,10 +14,21 @@ export interface FetchAreaResponse {
     GeoJSON.Geometry,
     FlowDestination
   >;
+  destinationPorts: GeoJSON.FeatureCollection<
+    GeoJSON.Geometry,
+    DestinationPort
+  >;
 }
 
 interface DestinationArea {
   id: string;
+  name: string;
+  geometry: string;
+}
+
+interface DestinationPort {
+  id: string;
+  id_int: string;
   name: string;
   geometry: string;
 }
@@ -41,16 +52,38 @@ export async function GET(
       return NextResponse.json({ error: "Area not found" }, { status: 404 });
     }
 
-    const [boundingBox, destinationAreas] = await Promise.all([
-      prisma.$queryRaw`
+    const [boundingBox, destinationAreas, destinationPortsFeatures] =
+      await Promise.all([
+        prisma.$queryRaw`
         SELECT ST_AsGeoJSON(ST_Extent(ST_Transform(limits, 4326))) as geojson FROM "Area" WHERE id = ${id}
       `,
-      prisma.$queryRaw`
+        prisma.$queryRaw`
         select "Area"."id", "Area"."name", ST_AsGeoJSON(ST_Transform(limits, 4326)) as geometry from "Flow" LEFT JOIN "Area" ON "Flow"."toAreaId" = "Area"."id" where "fromAreaId" = ${id};
       `,
-    ]);
+        // TODO this is a temporary query to get the 10 closest ports to the area until there is maritime data in the database
+        prisma.$queryRaw<DestinationPort[]>`
+          SELECT 
+            "Node"."id", 
+            ((ctid::text::point)[0]::bigint << 32) | (ctid::text::point)[1]::bigint AS id_int,
+            "Node"."name", 
+            ST_AsGeoJSON(ST_Transform("Node"."geom", 4326)) as geometry
+          FROM "Node"
+          WHERE "Node"."type" = 'PORT'
+          ORDER BY ST_Distance(
+            ST_Transform(
+              (SELECT ST_Centroid(ST_Transform("limits", 4326)) FROM "Area" WHERE "id" = ${id}),
+              4326
+            ),
+            ST_Transform("Node"."geom", 4326)
+          ) ASC
+          LIMIT 10;
+        `,
+      ]);
 
-    const flowDestinations = {
+    const flowDestinations: GeoJSON.FeatureCollection<
+      GeoJSON.Geometry,
+      FlowDestination
+    > = {
       type: "FeatureCollection",
       features: (destinationAreas as DestinationArea[]).map(
         ({ id, name, geometry }) => ({
@@ -64,11 +97,30 @@ export async function GET(
       ),
     };
 
-    const result = {
+    const destinationPorts: GeoJSON.FeatureCollection<
+      GeoJSON.Geometry,
+      FlowDestination
+    > = {
+      type: "FeatureCollection",
+      features: (destinationPortsFeatures as DestinationPort[]).map(
+        ({ id, id_int, name, geometry }) => ({
+          type: "Feature",
+          properties: {
+            id,
+            id_int: id_int.toString(),
+            name,
+          },
+          geometry: JSON.parse(geometry), // Parse the GeoJSON geometry
+        })
+      ),
+    };
+
+    const result: FetchAreaResponse = {
       ...area,
       boundingBox:
         JSON.parse((boundingBox as { geojson: string }[])[0]?.geojson) || null, // Extract the bounding box as GeoJSON
       flowDestinations,
+      destinationPorts,
     };
 
     return NextResponse.json(result);

--- a/src/app/api/areas/[id]/route.ts
+++ b/src/app/api/areas/[id]/route.ts
@@ -1,10 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 
+export interface FlowDestination {
+  id: string;
+  name: string;
+}
+
 export interface FetchAreaResponse {
   id: string;
   name: string;
-  boundingBox: GeoJSON.Feature | null;
+  boundingBox: GeoJSON.Feature;
+  flowDestinations: GeoJSON.FeatureCollection<
+    GeoJSON.Geometry,
+    FlowDestination
+  >;
+}
+
+interface DestinationArea {
+  id: string;
+  name: string;
+  geometry: string;
 }
 
 export async function GET(
@@ -26,13 +41,34 @@ export async function GET(
       return NextResponse.json({ error: "Area not found" }, { status: 404 });
     }
 
-    const boundingBox = (await prisma.$queryRaw`
-      SELECT ST_AsGeoJSON(ST_Extent(ST_Transform(limits, 4326))) as geojson FROM "Area" WHERE id = ${id}
-    `) as { geojson: string }[];
+    const [boundingBox, destinationAreas] = await Promise.all([
+      prisma.$queryRaw`
+        SELECT ST_AsGeoJSON(ST_Extent(ST_Transform(limits, 4326))) as geojson FROM "Area" WHERE id = ${id}
+      `,
+      prisma.$queryRaw`
+        select "Area"."id", "Area"."name", ST_AsGeoJSON(ST_Transform(limits, 4326)) as geometry from "Flow" LEFT JOIN "Area" ON "Flow"."toAreaId" = "Area"."id" where "fromAreaId" = ${id};
+      `,
+    ]);
+
+    const flowDestinations = {
+      type: "FeatureCollection",
+      features: (destinationAreas as DestinationArea[]).map(
+        ({ id, name, geometry }) => ({
+          type: "Feature",
+          properties: {
+            id,
+            name,
+          },
+          geometry: JSON.parse(geometry),
+        })
+      ),
+    };
 
     const result = {
       ...area,
-      boundingBox: JSON.parse(boundingBox[0]?.geojson) || null, // Extract the bounding box as GeoJSON
+      boundingBox:
+        JSON.parse((boundingBox as { geojson: string }[])[0]?.geojson) || null, // Extract the bounding box as GeoJSON
+      flowDestinations,
     };
 
     return NextResponse.json(result);

--- a/src/app/api/areas/[id]/route.ts
+++ b/src/app/api/areas/[id]/route.ts
@@ -61,7 +61,7 @@ export async function GET(
         select "Area"."id", "Area"."name", ST_AsGeoJSON(ST_Transform(limits, 4326)) as geometry from "Flow" LEFT JOIN "Area" ON "Flow"."toAreaId" = "Area"."id" where "fromAreaId" = ${id};
       `,
         // TODO this is a temporary query to get the 10 closest ports to the area until there is maritime data in the database
-        prisma.$queryRaw<DestinationPort[]>`
+        prisma.$queryRaw`
           SELECT 
             "Node"."id", 
             ((ctid::text::point)[0]::bigint << 32) | (ctid::text::point)[1]::bigint AS id_int,
@@ -99,7 +99,7 @@ export async function GET(
 
     const destinationPorts: GeoJSON.FeatureCollection<
       GeoJSON.Geometry,
-      FlowDestination
+      DestinationPort
     > = {
       type: "FeatureCollection",
       features: (destinationPortsFeatures as DestinationPort[]).map(
@@ -109,8 +109,9 @@ export async function GET(
             id,
             id_int: id_int.toString(),
             name,
+            geometry: JSON.parse(geometry),
           },
-          geometry: JSON.parse(geometry), // Parse the GeoJSON geometry
+          geometry: JSON.parse(geometry),
         })
       ),
     };

--- a/src/app/api/tiles/ports/[z]/[x]/[y]/route.ts
+++ b/src/app/api/tiles/ports/[z]/[x]/[y]/route.ts
@@ -29,9 +29,10 @@ export async function GET(
   const yNum = Number(y);
 
   const query = `
-    SELECT ST_AsMVT(tile) FROM (
+    SELECT ST_AsMVT(tile, 'default', 4096, 'geom', 'id_int') FROM (
       SELECT
         id,
+        ((ctid::text::point)[0]::bigint << 32) | (ctid::text::point)[1]::bigint AS id_int,
         name,
         ST_AsMVTGeom(
           geom,

--- a/src/app/components/charts/list-bars.tsx
+++ b/src/app/components/charts/list-bars.tsx
@@ -68,7 +68,13 @@ function Bar({
   );
 }
 
-function ListBars({ data, showPercentage, unit, formatType, decimalPlaces = 0 }: IListBars) {
+function ListBars({
+  data,
+  showPercentage,
+  unit,
+  formatType,
+  decimalPlaces = 0,
+}: IListBars) {
   const sum = useMemo(() => {
     return data.reduce((sum, { value }) => sum + value, 0);
   }, [data]);

--- a/src/app/components/map/layers/area.tsx
+++ b/src/app/components/map/layers/area.tsx
@@ -27,6 +27,8 @@ export const lineStyle: LineLayerSpecification["paint"] = {
     AREA_HIGHLIGHT_OUTLINE_COLOR,
     ["boolean", ["feature-state", "selected"], false],
     AREA_HIGHLIGHT_OUTLINE_COLOR,
+    ["boolean", ["feature-state", "destination"], false],
+    AREA_HIGHLIGHT_OUTLINE_COLOR,
     AREA_DEFAULT_OUTLINE_COLOR,
   ],
   "line-width": ["interpolate", ["exponential", 1.99], ["zoom"], 3, 1, 7, 3],

--- a/src/app/components/map/layers/ports.tsx
+++ b/src/app/components/map/layers/ports.tsx
@@ -42,7 +42,7 @@ const PortsLayer = () => {
         source-layer="default"
         layout={{
           "icon-image": "port-icon",
-          "icon-size": 0.9,
+          "icon-size": 0.5,
         }}
         filter={["in", "$id", ...destinationPortsIds]}
       />

--- a/src/app/components/map/layers/ports.tsx
+++ b/src/app/components/map/layers/ports.tsx
@@ -1,9 +1,14 @@
 import React, { useEffect } from "react";
 import { Source, Layer, useMap } from "react-map-gl";
+import { MachineContext } from "../state";
 
 const PortsLayer = () => {
   const map = useMap();
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  const destinationPortsIds = MachineContext.useSelector(
+    (s) => s.context.destinationPortsIds
+  );
 
   useEffect(() => {
     if (!map.current) return;
@@ -23,13 +28,23 @@ const PortsLayer = () => {
       tiles={[`${appUrl}/api/tiles/ports/{z}/{x}/{y}`]}
     >
       <Layer
-        id="ports-point"
+        id="top-ports"
         type="symbol"
         source-layer="default"
         layout={{
           "icon-image": "port-icon",
           "icon-size": 0.3,
         }}
+      />
+      <Layer
+        id="destination-ports"
+        type="symbol"
+        source-layer="default"
+        layout={{
+          "icon-image": "port-icon",
+          "icon-size": 0.9,
+        }}
+        filter={["in", "$id", ...destinationPortsIds]}
       />
     </Source>
   );

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -262,32 +262,6 @@ export const globeViewMachine = createMachine(
         };
       }),
 
-      "action:resetAreaHighlight": assign(({ context }) => {
-        const { mapRef, currentArea } = context;
-
-        if (mapRef && currentArea) {
-          const features = mapRef.querySourceFeatures("area-tiles", {
-            filter: ["==", "id", currentArea.id],
-            sourceLayer: "default",
-          });
-
-          for (let i = 0, len = features.length; i < len; i++) {
-            const feature = features[i];
-            if (feature.id) {
-              mapRef.setFeatureState(
-                {
-                  source: "area-tiles",
-                  sourceLayer: "default",
-                  id: feature.id,
-                },
-                { selected: false }
-              );
-            }
-          }
-        }
-
-        return {};
-      }),
       "action:setMapRef": assign(({ event }) => {
         assertEvent(event, "event:map:mount");
 
@@ -573,10 +547,6 @@ export const globeViewMachine = createMachine(
         const m = mapRef.getMap();
         m.setLayoutProperty("top-ports", "visibility", "none");
       },
-      "action:area:clear": assign({
-        currentAreaId: null,
-        currentArea: null,
-      }),
     },
     guards: {
       "guard:isWorldView": ({ context }) => {

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -39,7 +39,7 @@ interface StateContext {
 
 export const globeViewMachine = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJyunaFx6m6UnSGWcK1+Tb3RnN+5MKKp5RsF1M-AFiweMJIv-iz1rsuYgDMESqGRPfWS9k6TaSkKEV4PMAQGE8jec47ljztFGAXVCRJFzAI-MJYUYpJSQIol7OSVh4G3HYkMLeIRQikgLMEUsLR4LD0mmEZ07FSaATbFAy6XwnDfx3vUPeR5LATjCN6IEIxgQMVJE4XhX4gJSgET3OkwQTzWFrO0UIYRP6FmBFoz0WEQjVleBHWODdCLuzUeQ9e9ldEMjkd0fWmEg61ArEQeBrwqpFWeI8cEBDGpx1Entdq0Du59m+MSIMzhRqjQFmyGsbEDD3hmlpIMtZJpANmHXYyYTCJyyporKGVFomP1GD4l09wxiPArCwjSRJvRD1aCCBcdhrHhX1E3OK6iYlFV+KEL0AUFqPGBF5Z0jRQhYXeFpHMtVYhAA */
+    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJytIFt4mkdUnSGWcK1+Tb3RnN+5MKKp5RsF1M-AFiweMJIv-iz1rsuYgDMESqGRPfWS9k6TaSkKEV4PMAQGE8jec47ljztFGAXVCRJFzAI-MJYUYpJSQIol7OSVh4G3HYkMLeIRQikgLMEUsLR4LD0mmEZ07FSaATbFAy6XwnDfx3vUPeR5LATjCN6IEIxgQMVJE4XhX4gJSgET3OkwQTzWFrO0UIYRP6FmBFoz0WEQjVleBHWODdCLuzUeQ9e9ldEMjkd0fWmEg61ArEQeBrwqpFWeI8cEBDGpx1Entdq0Du59m+MSIMzhRqjQFmyGsbEDD3hmlpIMtZJpANmHXYyYTCJyyporKGVFomP1GD4l09wxiPArCwjSRJvRD1aCCBcdhrHhX1E3OK6iYlFV+KEL0AUFqPGBF5Z0jRQhYXeFpHMtVYhAA */
     id: "globeView",
 
     types: {
@@ -196,7 +196,8 @@ export const globeViewMachine = createMachine(
           },
         },
 
-        entry: "action:setTransportationAreaView",
+        entry: "action:enterTransportationAreaView",
+        exit: "action:exitTransportationAreaView",
       },
 
       "area:view:impact": {
@@ -404,7 +405,7 @@ export const globeViewMachine = createMachine(
         return {};
       }),
 
-      "action:setTransportationAreaView": assign(({ context }) => {
+      "action:enterTransportationAreaView": ({ context }) => {
         const { mapRef, currentArea } = context;
 
         if (mapRef && currentArea) {
@@ -451,9 +452,32 @@ export const globeViewMachine = createMachine(
             );
           }
         }
+      },
+      "action:exitTransportationAreaView": ({ context }) => {
+        const { mapRef, currentArea } = context;
 
-        return {};
-      }),
+        if (mapRef && currentArea) {
+          const destinationAreaIds = currentArea.flowDestinations.features.map(
+            ({ properties }) => properties.id
+          );
+
+          const features = mapRef.querySourceFeatures("area-tiles", {
+            filter: ["in", "id", ...destinationAreaIds],
+            sourceLayer: "default",
+          });
+
+          for (let i = 0, len = features.length; i < len; i++) {
+            mapRef.setFeatureState(
+              {
+                source: "area-tiles",
+                sourceLayer: "default",
+                id: features[i].id!,
+              },
+              { destination: false }
+            );
+          }
+        }
+      },
       "action:setImpactAreaView": assign(({ context }) => {
         const { mapRef } = context;
 

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -30,6 +30,7 @@ interface StateContext {
   currentArea: FetchAreaResponse | null;
   currentAreaFeature: GeoJSONFeature | null;
   currentAreaViewType: EAreaViewType | null;
+  destinationPortsIds: number[];
   mapPopup: IMapPopup | null;
   mapBounds: BBox | null;
   eventHandlers: {
@@ -39,7 +40,7 @@ interface StateContext {
 
 export const globeViewMachine = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJytIFt4mneGPa+XYhSGWcK1+Tb3RnN+5MKKp5RsF1M-AFiweKEiLv8WeN8PwMwRKoZET9ZL2TpNpKQoRXg8wBAYTyN5zjuWPO0UYBdUJEkXGAxqWphRiklNAiiXs5JWEQbcdiQwt4hFCKSAswRSwtHgsPSaYRnTsVJoBNsMDLpfCcH-He9Q95HksBOMI3ogQjGBAxUkTh+FfiAlKIRPc6TBBPNYWs7RQhhB-oWYEOjPRYRCNWV4EdY4N0Iu7DRlD172X0QyBR3R9aYSDrUCsRBEGvCqkVZ4jxwREPruFFqUV9rP3SjEuBgRxrOFGqNAWbIaxsQMPeGaWkgy1kmqA2YddjJx1EnLKmisoZUW7n2Scow-EunuGMR4FY2EaSJN6IerQQQLjsLYiJCdm5sE0TUoqvxQhegCgtR4wIvLOkaKELCV8kkkznkAA */
+    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJynCPP0iVq2Y68WUhlnCtfk290ZzfuTCiqeUbBdTPwBYsHjCRF3+LPWuy5iAMwRKoZEj9ZL2TpNpKQoRXg8wBAYTyN5zjuWPO0UYBdUJEkXKAj8wlhRiklNAiiXs5JWEQbcdiQwt4hFCKSAswRSwtHgsPSaYRnTsVJoBNsMDLpfCcL-He9Q95HksBOMI3ogQjGBAxUkTh+FfiAlKIRPc6TBBPNYWs7RQhhG-oWYEOjPRYRCNWV4EdY4N0Iu7DRlD172X0QyBR3R9aYSDrUCsRBEGvCqkVZ4jxwREManHUSe12qwO7n2b4xIgzOFGqNAWbIaxsQMPeGaWkgy1kmiA6+YCyb20InLKmisoZUVic-UYfiXT3DGI8CsbCNKX1uE0VoIIFx2FseFfUTc4qaLiUVX4oQvQBQWo8YEXlnSNFCFhd4Wkcy1ViEAA */
     id: "globeView",
 
     types: {
@@ -56,6 +57,7 @@ export const globeViewMachine = createMachine(
       currentArea: null,
       currentAreaFeature: null,
       currentAreaViewType: null,
+      destinationPortsIds: [],
       mapPopup: null,
       mapBounds: null,
       eventHandlers: {
@@ -155,6 +157,8 @@ export const globeViewMachine = createMachine(
             reenter: true,
           },
         ],
+
+        entry: "action:enterAreaView",
       },
 
       "area:view:production": {
@@ -307,7 +311,7 @@ export const globeViewMachine = createMachine(
         }
 
         const features = mapRef.queryRenderedFeatures(event.mapEvent.point, {
-          layers: ["ports-point", "area-clickable-polygon"],
+          layers: ["top-ports", "area-clickable-polygon"],
         });
 
         const feature = features && features[0];
@@ -319,7 +323,7 @@ export const globeViewMachine = createMachine(
         }
 
         const layerToIconTypeMap: Record<string, EItemType> = {
-          "ports-point": EItemType.node,
+          "top-ports": EItemType.node,
           "area-clickable-polygon": EItemType.area,
         };
 
@@ -408,55 +412,63 @@ export const globeViewMachine = createMachine(
         return {};
       }),
 
-      "action:enterTransportationAreaView": ({ context }) => {
+      "action:enterTransportationAreaView": assign(({ context }) => {
         const { mapRef, currentArea } = context;
 
-        if (mapRef && currentArea) {
-          const m = mapRef.getMap();
-          m.setLayoutProperty("foodgroups-layer", "visibility", "none");
+        if (!mapRef || !currentArea) return {};
 
-          const destinationAreaIds = currentArea.flowDestinations.features.map(
-            ({ properties }) => properties.id
-          );
-          const destinationAreaBbox = bbox(currentArea.flowDestinations);
-          const combinedBboxes = combineBboxes([
-            destinationAreaBbox,
-            bbox(currentArea.boundingBox),
-          ]);
+        const m = mapRef.getMap();
+        m.setLayoutProperty("foodgroups-layer", "visibility", "none");
 
-          mapRef.fitBounds(
-            [
-              [combinedBboxes[0], combinedBboxes[1]],
-              [combinedBboxes[2], combinedBboxes[3]],
-            ],
-            {
-              padding: {
-                top: 100,
-                left: 100,
-                bottom: 100,
-                right: 100,
-              },
-            }
-          );
+        const destinationAreaIds = currentArea.flowDestinations.features.map(
+          ({ properties }) => properties.id
+        );
+        const destinationAreaBbox = bbox(currentArea.flowDestinations);
+        const destinationPortsBbox = bbox(currentArea.destinationPorts);
+        const combinedBboxes = combineBboxes([
+          destinationAreaBbox,
+          destinationPortsBbox,
+          bbox(currentArea.boundingBox),
+        ]);
 
-          // highlight destination areas
-          const features = mapRef.querySourceFeatures("area-tiles", {
-            filter: ["in", "id", ...destinationAreaIds],
-            sourceLayer: "default",
-          });
-          for (let i = 0, len = features.length; i < len; i++) {
-            mapRef.setFeatureState(
-              {
-                source: "area-tiles",
-                sourceLayer: "default",
-                id: features[i].id!,
-              },
-              { destination: true }
-            );
+        mapRef.fitBounds(
+          [
+            [combinedBboxes[0], combinedBboxes[1]],
+            [combinedBboxes[2], combinedBboxes[3]],
+          ],
+          {
+            padding: {
+              top: 100,
+              left: 100,
+              bottom: 100,
+              right: 100,
+            },
           }
+        );
+
+        // highlight destination areas
+        const features = mapRef.querySourceFeatures("area-tiles", {
+          filter: ["in", "id", ...destinationAreaIds],
+          sourceLayer: "default",
+        });
+        for (let i = 0, len = features.length; i < len; i++) {
+          mapRef.setFeatureState(
+            {
+              source: "area-tiles",
+              sourceLayer: "default",
+              id: features[i].id!,
+            },
+            { destination: true }
+          );
         }
-      },
-      "action:exitTransportationAreaView": ({ context }) => {
+
+        const destinationPortsIds = currentArea.destinationPorts.features.map(
+          ({ properties }) => parseInt(properties.id_int)
+        );
+
+        return { destinationPortsIds };
+      }),
+      "action:exitTransportationAreaView": assign(({ context }) => {
         const { mapRef, currentArea } = context;
 
         if (mapRef && currentArea) {
@@ -480,7 +492,11 @@ export const globeViewMachine = createMachine(
             );
           }
         }
-      },
+
+        return {
+          destinationPortsIds: [],
+        };
+      }),
       "action:setImpactAreaView": assign(({ context }) => {
         const { mapRef } = context;
 
@@ -525,6 +541,9 @@ export const globeViewMachine = createMachine(
         const { mapRef, currentAreaFeature } = context;
 
         if (mapRef) {
+          const m = mapRef.getMap();
+          m.setLayoutProperty("top-ports", "visibility", "visible");
+
           if (currentAreaFeature?.id) {
             mapRef.setFeatureState(
               {
@@ -546,6 +565,14 @@ export const globeViewMachine = createMachine(
           currentAreaFeature: null,
         };
       }),
+      "action:enterAreaView": ({ context }) => {
+        const { mapRef } = context;
+
+        if (!mapRef) return;
+
+        const m = mapRef.getMap();
+        m.setLayoutProperty("top-ports", "visibility", "none");
+      },
       "action:area:clear": assign({
         currentAreaId: null,
         currentArea: null,

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -394,10 +394,10 @@ export const globeViewMachine = createMachine(
         const m = mapRef.getMap();
         m.setLayoutProperty("foodgroups-layer", "visibility", "none");
 
-        const destinationAreaIds = currentArea.flowDestinations.features.map(
+        const destinationAreaIds = currentArea.destinationAreas.features.map(
           ({ properties }) => properties.id
         );
-        const destinationAreaBbox = bbox(currentArea.flowDestinations);
+        const destinationAreaBbox = bbox(currentArea.destinationAreas);
         const destinationPortsBbox = bbox(currentArea.destinationPorts);
         const combinedBboxes = combineBboxes([
           destinationAreaBbox,
@@ -446,7 +446,7 @@ export const globeViewMachine = createMachine(
         const { mapRef, currentArea } = context;
 
         if (mapRef && currentArea) {
-          const destinationAreaIds = currentArea.flowDestinations.features.map(
+          const destinationAreaIds = currentArea.destinationAreas.features.map(
             ({ properties }) => properties.id
           );
 

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -430,7 +430,7 @@ export const globeViewMachine = createMachine(
             {
               source: "area-tiles",
               sourceLayer: "default",
-              id: features[i].id!,
+              id: features[i].id ?? "",
             },
             { destination: true }
           );
@@ -460,7 +460,7 @@ export const globeViewMachine = createMachine(
               {
                 source: "area-tiles",
                 sourceLayer: "default",
-                id: features[i].id!,
+                id: features[i].id ?? "",
               },
               { destination: false }
             );

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -39,7 +39,7 @@ interface StateContext {
 
 export const globeViewMachine = createMachine(
   {
-    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJytIFt4mkdUnSGWcK1+Tb3RnN+5MKKp5RsF1M-AFiweMJIv-iz1rsuYgDMESqGRPfWS9k6TaSkKEV4PMAQGE8jec47ljztFGAXVCRJFzAI-MJYUYpJSQIol7OSVh4G3HYkMLeIRQikgLMEUsLR4LD0mmEZ07FSaATbFAy6XwnDfx3vUPeR5LATjCN6IEIxgQMVJE4XhX4gJSgET3OkwQTzWFrO0UIYRP6FmBFoz0WEQjVleBHWODdCLuzUeQ9e9ldEMjkd0fWmEg61ArEQeBrwqpFWeI8cEBDGpx1Entdq0Du59m+MSIMzhRqjQFmyGsbEDD3hmlpIMtZJpANmHXYyYTCJyyporKGVFomP1GD4l09wxiPArCwjSRJvRD1aCCBcdhrHhX1E3OK6iYlFV+KEL0AUFqPGBF5Z0jRQhYXeFpHMtVYhAA */
+    /** @xstate-layout N4IgpgJg5mDOIC5RQDYHsBGYBqBLMA7gHQFoBOKECAbvgQMRjVgB2ALggLYCGADl2gCusMJzTMA2gAYAuolC80sXG1xoW8kAA9EARgAcAZiIB2AGz7dUswE4ArHbOGATDYA0IAJ6I7zoobNfQwAWYJCnKRtnAF9oj1RMHDoSckoaOkZmdi4+AWEwITZpOSQQRWVVdU0dBEM7KSIbfTMTZ10bFydg-Q9vBAMG3RcpXWdXYOsnG1j49Cw8QhSKKlpCTNYOQQoEDbAyYs1ylTUNUpqAWkNDfSJ9ZzMpMYfnQyl9dy9Ec9siA11dEx2GxNe4GYIzEAJebJHj8MSCdi4FhQdbZWF5dgHUpHSqnUAXMy6OxEZzmO5SOqjRwfPrfaxEUI2N5Ah6AuwmCFQpKLbhkMDcBAAMzAbAAxgALJEoiDqMBEJHUNAAazlXIWxF5-KFIolUoQCrQou4uOKWIUSmOVTOehGfnq13ewTM3QBhl6iGcUhMDJMXoCvuBhiJnLm3OIvG4MAQ6G4EHoZrKFtx1S+HVMDl8vl0wXqQLs7oQ52cdl0DMcJmCYxMNhMrSGIcS6qIEajMbjEl0JXNFROKYQrUGLOLNlGjzuBfOBm9w0rL3+vruDehixbYGjaFj8ecXcTPat+JthhsRBaR5c12zBh6n0LLSI5bCXv+umdBiXYebkbX8MRyNRHFXDEilkQ4k17a1bwBRoHWzOp9AcIwJ2aYkbBaatuidd4onfJtNQFVYCB2dg9ileMQOxMD920RATBCX4X2LUYX18d4CzsUIGUMWs7DuDpHBfHDkjw9JCCItgSL-DsdxxcCD37bNGmzZ1UMiSx2QLf4zD8T0rkrKl7laQSeT5fC6DEiSUQkbdQL3PFqP7ex-BHRwc2zExs2cDTbAaat7CMIFmiJQwjI1EyRMI3gyDQCBBFFXF-wQLYUHM-ZyO7S07IuK4bjuZ57keV59HgtjK1+Iq-KkKRHB4jk4khUNcLCgiEEi6LYvipgNhyOEhBEMRJDS3cMr7YJq38f5gnsAEjHudiC30J17yql4Rw6LDpjqtUhKaszWpiuKTgS9F4REQoExkqiamcO573ch4LAmIqC1sMxGhHJ1mOuJ0Yk2hrtq1Zq2DIbgWFgRQyDYY1Ds67IkpS87KMyr5stufKngKt5ipvf4gUadjJpLQIRnZEKiGEwHgdB8HIY6rIOGO3rRHEMAEdsvsnhPdijxsJ0R0sExrz6IYvV+O72WBBbJdJ8mzKBkGwfIGnobp7q8lOwRgOkxGRseW6gzeWj7qJMwNLCY9XAHdp6ngmtpZ20TcE4CM4oSuHdlSrW2Ygy5rlRvLnkKmk9AsG4HD9MwnCMJwzDtgGzMd522CO3ITqZgbPeGiCXG9HmeYj5pugrE3sfsYli0qocHBCYLfsbf7TIdp3uBdmH6ZTxmzsGi6kf6LTFK41D3gW4sTA03KfU0lpTzGfRYjqlhorgTQtsIGzM7k759B89iw5eCkml0CcrEsJytIFt4mneGPa+XYhSGWcK1+Tb3RnN+5MKKp5RsF1M-AFiweKEiLv8WeN8PwMwRKoZET9ZL2TpNpKQoRXg8wBAYTyN5zjuWPO0UYBdUJEkXGAxqWphRiklNAiiXs5JWEQbcdiQwt4hFCKSAswRSwtHgsPSaYRnTsVJoBNsMDLpfCcH-He9Q95HksBOMI3ogQjGBAxUkTh+FfiAlKIRPc6TBBPNYWs7RQhhB-oWYEOjPRYRCNWV4EdY4N0Iu7DRlD172X0QyBR3R9aYSDrUCsRBEGvCqkVZ4jxwREPruFFqUV9rP3SjEuBgRxrOFGqNAWbIaxsQMPeGaWkgy1kmqA2YddjJx1EnLKmisoZUW7n2Scow-EunuGMR4FY2EaSJN6IerQQQLjsLYiJCdm5sE0TUoqvxQhegCgtR4wIvLOkaKELCV8kkkznkAA */
     id: "globeView",
 
     types: {
@@ -104,7 +104,7 @@ export const globeViewMachine = createMachine(
           }),
           onDone: {
             target: "area:view:entering",
-            actions: ["action:setCurrentArea", "action:setAreaMapView"],
+            actions: ["action:setCurrentArea"],
             reenter: true,
           },
         },
@@ -175,7 +175,10 @@ export const globeViewMachine = createMachine(
           },
         },
 
-        entry: "action:setProductionAreaView",
+        entry: [
+          "action:fitMapToCurrentAreaBounds",
+          "action:setProductionAreaView",
+        ],
       },
 
       "area:view:transportation": {
@@ -218,7 +221,7 @@ export const globeViewMachine = createMachine(
           },
         },
 
-        entry: "action:setImpactAreaView",
+        entry: ["action:fitMapToCurrentAreaBounds", "action:setImpactAreaView"],
       },
     },
 
@@ -488,7 +491,7 @@ export const globeViewMachine = createMachine(
 
         return {};
       }),
-      "action:setAreaMapView": assign(({ context }) => {
+      "action:fitMapToCurrentAreaBounds": assign(({ context }) => {
         const { mapRef, currentArea } = context;
 
         if (!mapRef || !currentArea || !currentArea.boundingBox) {

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -49,8 +49,11 @@ interface ActionEnterProductionAreaView {
   type: "action:setProductionAreaView";
 }
 
-interface ActionSetTransportationAreaView {
-  type: "action:setTransportationAreaView";
+interface ActionEnterTransportationAreaView {
+  type: "action:enterTransportationAreaView";
+}
+interface ActionExitTransportationAreaView {
+  type: "action:exitTransportationAreaView";
 }
 
 interface ActionSetImpactAreaView {
@@ -74,7 +77,8 @@ export type StateActions =
   | ActionSetCurrentAreaId
   | ActionSetCurrentArea
   | ActionEnterProductionAreaView
-  | ActionSetTransportationAreaView
+  | ActionEnterTransportationAreaView
+  | ActionExitTransportationAreaView
   | ActionSetImpactAreaView
   | ActionSetAreaMapView
   | ActionEnterWorldMapView

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -63,6 +63,10 @@ interface ActionSetImpactAreaView {
 interface ActionEnterWorldMapView {
   type: "action:enterWorldMapView";
 }
+
+interface ActionEnterAreaView {
+  type: "action:enterAreaView";
+}
 interface ActionAreaClear {
   type: "action:area:clear";
 }
@@ -82,4 +86,5 @@ export type StateActions =
   | ActionSetImpactAreaView
   | ActionSetAreaMapView
   | ActionEnterWorldMapView
+  | ActionEnterAreaView
   | ActionAreaClear;

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -43,7 +43,7 @@ interface ActionSetCurrentArea {
 }
 
 interface ActionSetAreaMapView {
-  type: "action:setAreaMapView";
+  type: "action:fitMapToCurrentAreaBounds";
 }
 interface ActionEnterProductionAreaView {
   type: "action:setProductionAreaView";

--- a/src/app/components/map/state/types/actions.ts
+++ b/src/app/components/map/state/types/actions.ts
@@ -14,10 +14,6 @@ interface ActionParseAreaSection {
   type: "action:parseAreaSection";
 }
 
-interface ResetAreaHighlight {
-  type: "action:resetAreaHighlight";
-}
-
 interface ActionSetMapRef {
   type: "action:setMapRef";
   mapRef: MapRef;
@@ -67,14 +63,10 @@ interface ActionEnterWorldMapView {
 interface ActionEnterAreaView {
   type: "action:enterAreaView";
 }
-interface ActionAreaClear {
-  type: "action:area:clear";
-}
 
 export type StateActions =
   | ActionParseUrl
   | ActionParseAreaSection
-  | ResetAreaHighlight
   | ActionSetMapRef
   | ActionSetHighlightedArea
   | ActionClearHighlightedArea
@@ -86,5 +78,4 @@ export type StateActions =
   | ActionSetImpactAreaView
   | ActionSetAreaMapView
   | ActionEnterWorldMapView
-  | ActionEnterAreaView
-  | ActionAreaClear;
+  | ActionEnterAreaView;

--- a/src/app/components/map/state/types/events.ts
+++ b/src/app/components/map/state/types/events.ts
@@ -32,10 +32,6 @@ interface EventFetchAreaDone {
   output: FetchAreaResponse;
 }
 
-interface EventAreaClear {
-  type: "event:area:clear";
-}
-
 interface EventAreaSelectFoodTransportation {
   type: "event:area:selectFoodTransportation";
 }
@@ -54,7 +50,6 @@ export type StateEvents =
   | EventMapMount
   | EventMapMouseMove
   | EventFetchAreaDone
-  | EventAreaClear
   | EventMapMouseOut
   | EventAreaSelectFoodTransportation
   | EventAreaSelectImpact

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -1,0 +1,17 @@
+import { BBox } from "geojson";
+
+export function combineBboxes(bboxes: BBox[]): BBox {
+  let minLeft: number = 180;
+  let minBottom: number = 90;
+  let maxRight: number = -180;
+  let maxTop: number = -90;
+
+  bboxes.forEach(([left, bottom, right, top]) => {
+    if (left < minLeft) minLeft = left;
+    if (bottom < minBottom) minBottom = bottom;
+    if (right > maxRight) maxRight = right;
+    if (top > maxTop) maxTop = top;
+  });
+
+  return [minLeft, minBottom, maxRight, maxTop];
+}

--- a/src/utils/geometries.ts
+++ b/src/utils/geometries.ts
@@ -1,10 +1,10 @@
 import { BBox } from "geojson";
 
 export function combineBboxes(bboxes: BBox[]): BBox {
-  let minLeft: number = 180;
-  let minBottom: number = 90;
-  let maxRight: number = -180;
-  let maxTop: number = -90;
+  let minLeft = 180;
+  let minBottom = 90;
+  let maxRight = -180;
+  let maxTop = -90;
 
   bboxes.forEach(([left, bottom, right, top]) => {
     if (left < minLeft) minLeft = left;


### PR DESCRIPTION
This aims to add the map transitions between food produced and transportation states. This PR is based on the changes introduced in #84. I created a new branch because `produced-transport-transition` got outdated with the various PRs we merged today and it was hard to fix the merge conflicts. 

Changes added:

- Toggle destination areas
- Renamed layer `ports-points` to `top-ports`, which should be rendered in the world view exclusively
- Added `destination-ports` layer to be rendered in the transportation view
- Fixed lint/type issues

Screen capture:

![transportation](https://github.com/user-attachments/assets/1f2b74b1-40af-464b-b50a-2ec2481a0864)

@oliverroick this is ready for a first review, please feel free to add changes.