### PR TITLE
Add arc diagrams

### DIFF
--- a/prisma/seed/nodes.ts
+++ b/prisma/seed/nodes.ts
@@ -15,7 +15,7 @@ import {
 import fs from "fs-extra";
 import { parse } from "csv-parse";
 
-enum IndicatorColumn {
+export enum IndicatorColumn {
   LIVESTOCK_SUM = "livestock_sum",
   TRAVEL_MEAN = "travel_mean",
   NUM_F_CHILDBEARING = "num_f_childbearing",

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -244,7 +244,7 @@ const AreaPage = async ({
             }}
           />
         </PageSection>
-        <PageSection id={EAreaViewType.impact}>
+        <PageSection id={EAreaViewType.impact} className="pb-8">
           <SectionHeader label="Impact on people" />
           <MetricRow>
             <Metric

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -5,9 +5,9 @@ import { EItemType } from "@/types/components";
 import ScrollTracker from "./scroll-tracker";
 import { PageSection, SectionHeader } from "@/app/components/page-section";
 import { Metric, MetricRow } from "@/app/components/metric";
-import { AreaMeta } from "../../../../../prisma/seed/nodes";
+import { AreaMeta, IndicatorColumn } from "../../../../../prisma/seed/nodes";
 import { FoodGroup, Prisma } from "@prisma/client";
-import { ListBars, Sankey } from "@/app/components/charts";
+import { Arc, ListBars, Sankey } from "@/app/components/charts";
 import { formatKeyIndicator } from "@/utils/numbers";
 import { EAreaViewType } from "@/app/components/map/state/machine";
 
@@ -236,7 +236,12 @@ const AreaPage = async ({
         </PageSection>
         <PageSection id={EAreaViewType.impact}>
           <SectionHeader label="Impact on people" />
-          <div className="bg-neutral-100 h-[400px]">chart</div>
+          <div className="flex flex-wrap gap-6 justify-around items-end">
+            {meta[IndicatorColumn.PCT_RURAL] && <Arc title="Rural" percentage={meta[IndicatorColumn.PCT_RURAL]} />}
+            {meta[IndicatorColumn.PCT_ELDERLY] && <Arc title="Elderly" percentage={meta[IndicatorColumn.PCT_ELDERLY]} />}
+            {meta[IndicatorColumn.PCT_F_CHILDBEARING] && <Arc title="Women of child-bearing age" percentage={meta[IndicatorColumn.PCT_F_CHILDBEARING]} />}
+            {meta[IndicatorColumn.PCT_UNDER5] && <Arc title="Children under 5" percentage={meta[IndicatorColumn.PCT_UNDER5]} />}
+          </div>
         </PageSection>
       </ScrollTracker>
     </div>

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -236,11 +236,19 @@ const AreaPage = async ({
         </PageSection>
         <PageSection id={EAreaViewType.impact}>
           <SectionHeader label="Impact on people" />
+          <MetricRow>
+            <Metric
+              label="Number of people"
+              value={meta[IndicatorColumn.TOTALPOP]}
+              formatType="metric"
+              decimalPlaces={0}
+            />
+          </MetricRow>
           <div className="flex flex-wrap gap-6 justify-around items-end">
-            {meta[IndicatorColumn.PCT_RURAL] && <Arc title="Rural" percentage={meta[IndicatorColumn.PCT_RURAL]} />}
-            {meta[IndicatorColumn.PCT_ELDERLY] && <Arc title="Elderly" percentage={meta[IndicatorColumn.PCT_ELDERLY]} />}
-            {meta[IndicatorColumn.PCT_F_CHILDBEARING] && <Arc title="Women of child-bearing age" percentage={meta[IndicatorColumn.PCT_F_CHILDBEARING]} />}
-            {meta[IndicatorColumn.PCT_UNDER5] && <Arc title="Children under 5" percentage={meta[IndicatorColumn.PCT_UNDER5]} />}
+            {meta[IndicatorColumn.PCT_RURAL] !== undefined && <Arc title="Rural" percentage={meta[IndicatorColumn.PCT_RURAL]} />}
+            {meta[IndicatorColumn.PCT_ELDERLY] !== undefined && <Arc title="Elderly" percentage={meta[IndicatorColumn.PCT_ELDERLY]} />}
+            {meta[IndicatorColumn.PCT_F_CHILDBEARING] !== undefined && <Arc title="Women of child-bearing age" percentage={meta[IndicatorColumn.PCT_F_CHILDBEARING]} />}
+            {meta[IndicatorColumn.PCT_UNDER5] !== undefined && <Arc title="Children under 5" percentage={meta[IndicatorColumn.PCT_UNDER5]} />}
           </div>
         </PageSection>
       </ScrollTracker>

--- a/src/app/components/charts/arc.tsx
+++ b/src/app/components/charts/arc.tsx
@@ -42,7 +42,7 @@ function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
         innerRadius: INNER_RADIUS,
         outerRadius: OUTER_RADIUS,
         startAngle: 0,
-        endAngle: percentage * tau
+        endAngle: percentage / 100 * tau
       })
       .style("fill", "rgba(255, 149, 113, 1)")
       .attr("d", arc);
@@ -50,9 +50,9 @@ function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
 
   return (
     <div className="relative" style={{ width: `${width}px`}}>
-      <h4 className="text-center text-sm mb-2">{title}</h4>
+      <h4 className="text-center text-xs mb-2">{title}</h4>
       <div className="absolute bottom-0 left-0 right-0">
-        <span className="block text-xl text-center">{(percentage * 100).toFixed(1)}</span>
+        <span className="block text-xl text-center">{percentage.toFixed(1)}</span>
         <span className="block text-xs text-center">%</span>
       </div>
       <svg width={width} height={height} ref={ref} />

--- a/src/app/components/charts/arc.tsx
+++ b/src/app/components/charts/arc.tsx
@@ -17,10 +17,13 @@ function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
 
   useEffect(() => {
     const svg = d3.select(ref.current);
-    const g = svg.append("g").attr("transform", `translate(${width / 2}, ${height}) rotate(-90)`);
-    const tau = 2 * Math.PI / 2;
+    const g = svg
+      .append("g")
+      .attr("transform", `translate(${width / 2}, ${height}) rotate(-90)`);
+    const tau = (2 * Math.PI) / 2;
 
-    const arc = d3.arc()
+    const arc = d3
+      .arc()
       .innerRadius(INNER_RADIUS)
       .outerRadius(OUTER_RADIUS)
       .startAngle(0);
@@ -31,7 +34,7 @@ function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
         innerRadius: INNER_RADIUS,
         outerRadius: OUTER_RADIUS,
         startAngle: 0,
-        endAngle: tau
+        endAngle: tau,
       })
       .style("fill", "rgba(231, 229, 228, 1)")
       .attr("d", arc);
@@ -42,22 +45,24 @@ function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
         innerRadius: INNER_RADIUS,
         outerRadius: OUTER_RADIUS,
         startAngle: 0,
-        endAngle: percentage / 100 * tau
+        endAngle: (percentage / 100) * tau,
       })
       .style("fill", "rgba(255, 149, 113, 1)")
       .attr("d", arc);
   }, []);
 
   return (
-    <div className="relative" style={{ width: `${width}px`}}>
+    <div className="relative" style={{ width: `${width}px` }}>
       <h4 className="text-center text-xs mb-2">{title}</h4>
       <div className="absolute bottom-0 left-0 right-0">
-        <span className="block text-xl text-center">{percentage.toFixed(1)}</span>
+        <span className="block text-xl text-center">
+          {percentage.toFixed(1)}
+        </span>
         <span className="block text-xs text-center">%</span>
       </div>
       <svg width={width} height={height} ref={ref} />
     </div>
-  )
+  );
 }
 
 export default Arc;

--- a/src/app/components/charts/arc.tsx
+++ b/src/app/components/charts/arc.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useRef } from "react";
+import * as d3 from "d3";
+
+const INNER_RADIUS = 64;
+const OUTER_RADIUS = 72;
+
+interface IArc {
+  title: string;
+  percentage: number;
+  width?: number;
+  height?: number;
+}
+
+function Arc({ title, percentage, width = 144, height = 72 }: IArc) {
+  const ref = useRef<SVGSVGElement>(null);
+
+  useEffect(() => {
+    const svg = d3.select(ref.current);
+    const g = svg.append("g").attr("transform", `translate(${width / 2}, ${height}) rotate(-90)`);
+    const tau = 2 * Math.PI / 2;
+
+    const arc = d3.arc()
+      .innerRadius(INNER_RADIUS)
+      .outerRadius(OUTER_RADIUS)
+      .startAngle(0);
+
+    // Append arc
+    g.append("path")
+      .datum({
+        innerRadius: INNER_RADIUS,
+        outerRadius: OUTER_RADIUS,
+        startAngle: 0,
+        endAngle: tau
+      })
+      .style("fill", "rgba(231, 229, 228, 1)")
+      .attr("d", arc);
+
+    // Fill percentage
+    g.append("path")
+      .datum({
+        innerRadius: INNER_RADIUS,
+        outerRadius: OUTER_RADIUS,
+        startAngle: 0,
+        endAngle: percentage * tau
+      })
+      .style("fill", "rgba(255, 149, 113, 1)")
+      .attr("d", arc);
+  }, []);
+
+  return (
+    <div className="relative" style={{ width: `${width}px`}}>
+      <h4 className="text-center text-sm mb-2">{title}</h4>
+      <div className="absolute bottom-0 left-0 right-0">
+        <span className="block text-xl text-center">{(percentage * 100).toFixed(1)}</span>
+        <span className="block text-xs text-center">%</span>
+      </div>
+      <svg width={width} height={height} ref={ref} />
+    </div>
+  )
+}
+
+export default Arc;

--- a/src/app/components/charts/index.ts
+++ b/src/app/components/charts/index.ts
@@ -1,5 +1,6 @@
 "use client";
+import Arc from "./arc";
 import ListBars from "./list-bars";
 import Sankey from "./sankey";
 
-export { ListBars, Sankey };
+export { Arc, ListBars, Sankey };

--- a/src/app/components/page-section.tsx
+++ b/src/app/components/page-section.tsx
@@ -42,11 +42,12 @@ export function SectionHeader({ label, tooltip }: ISectionHeader) {
 interface IPageSection {
   id: string;
   children: React.ReactNode;
+  className?: string;
 }
 
-export function PageSection({ id, children }: IPageSection) {
+export function PageSection({ id, children, className = "" }: IPageSection) {
   return (
-    <div id={id} className="p-4">
+    <div id={id} className={`p-4 ${className}`}>
       {children}
     </div>
   );

--- a/src/app/sandbox/components/page.tsx
+++ b/src/app/sandbox/components/page.tsx
@@ -194,7 +194,7 @@ export default function Components() {
       </div>
 
       <div className="w-[480px] mb-8">
-        <Arc title="Rural" percentage={.54365} />
+        <Arc title="Rural" percentage={0.54365} />
       </div>
     </div>
   );

--- a/src/app/sandbox/components/page.tsx
+++ b/src/app/sandbox/components/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ListBars, Sankey } from "@/app/components/charts";
+import { Arc, ListBars, Sankey } from "@/app/components/charts";
 import { MetricRow, Metric } from "@/app/components/metric";
 import PageHeader from "@/app/components/page-header";
 import {
@@ -191,6 +191,10 @@ export default function Components() {
             ],
           }}
         />
+      </div>
+
+      <div className="w-[480px] mb-8">
+        <Arc title="Rural" percentage={.54365} />
       </div>
     </div>
   );


### PR DESCRIPTION
Adds content to impact section

<img width="441" alt="Screenshot 2024-10-25 at 15 37 52" src="https://github.com/user-attachments/assets/8bd1b8b7-a653-4358-b060-52bbf3fe417b">

- Adds new chart component `Arc`
- Adds the `Arc` instances to the impact section on the production area page
- Adds key impact indicator on the production area page. (It looks like we only have the total population, but not the number of people in poverty 