### PR TITLE
fix: Set side panel to fixed width

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -138,7 +138,7 @@ const AreaPage = async ({
 
   return (
     <div
-      className={`w-[600px] bg-white h-screen grid grid-rows-[max-content_1fr]`}
+      className={`w-[480px] bg-white h-screen grid grid-rows-[max-content_1fr]`}
     >
       <PageHeader title={areaLabel} itemType={EItemType.area} />
       {totalFlow === 0 ? (
@@ -222,7 +222,7 @@ const AreaPage = async ({
               />
             </MetricRow>
             <Sankey
-              width={400}
+              width={435}
               height={600}
               data={{
                 nodes: [

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -92,7 +92,7 @@ function GlobeInner() {
   }, []);
 
   return (
-    <div className="flex flex-col w-full h-full relative">
+    <div className="w-full h-full relative flex-1">
       <Legend />
       <Map
         mapboxAccessToken={mapboxAccessToken}


### PR DESCRIPTION
- Removes flex-box CSS from map container, ensuring the side bar always has a fixed width.
- Set the Sankey width accordingly, removing the overflow. 