### PR TITLE
Ingest final data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ To set up the development environment for this website, you'll need to install t
 - [GDAL](https://gdal.org/)
 - [PostgreSQL](https://www.postgresql.org/)
 
+## Download seed data
+
+The data files are hosted in Google Drive. The recommended approach to download them is:
+
+1. Install the Google Drive desktop app for your operating system
+2. In the Google Drive app, sync the Food Twin 2.0/Version3 folder
+3. Copy the files to your local seed data directory using rsync to resolve symlinks:
+
+```bash
+# Replace SOURCE_PATH with your Google Drive folder path
+# TARGET_PATH should match SEED_DATA_PATH in your .env file
+rsync -av --copy-links "SOURCE_PATH/Food Twin 2.0/Version3/" TARGET_PATH/
+```
+
 ### Initialize `.env.local` File
 
 The project uses environment variables, which are set by default in the [.env](.env) file. To customize these variables (e.g., to use a custom database), create a `.env.local` file at the root of the repository (`cp .env .env.local`) and modify as needed.
@@ -41,8 +55,6 @@ Start database server:
 ```sh
 docker-compose up
 ```
-
-Download seed data and place it into the folder specified by `SEED_DATA_PATH` in the [.env](.env) file.
 
 Apply migrations and ingest seed data:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "prisma generate"
   },
   "prisma": {
-    "seed": "node --max-old-space-size=12096 --import tsx prisma/seed"
+    "seed": "node --max-old-space-size=65536 --import tsx prisma/seed"
   },
   "dependencies": {
     "@deck.gl/core": "^9.0.14",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:seed": "prisma migrate reset",
     "db:dump": "node prisma/db-dump.js",
     "db:restore": "node prisma/db-restore.js",
+    "db:aggregate-edges": "node prisma/tasks/aggregate-edges.js",
     "studio": "prisma studio",
     "postinstall": "prisma generate"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.1",
     "fs-extra": "^11.2.0",
+    "p-limit": "^6.2.0",
     "postcss": "^8.4.38",
     "prettier": "3.2.5",
     "sqlite": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
+      p-limit:
+        specifier: ^6.2.0
+        version: 6.2.0
       postcss:
         specifier: ^8.4.38
         version: 8.4.47
@@ -174,7 +177,7 @@ packages:
     resolution: {integrity: sha512-AMN6l3CF2ZeF+tVJC3zF/Bx+dVctTURj3vPLOAyylhh9RPjF91q1oNyOYE9qizuwQ7krzH3v3yW9vFOjiBKjIw==}
 
   '@deck.gl/extensions@9.0.32':
-    resolution: {integrity: sha512-RfktqFS8IU9TlYwZijWoQqW2oXYW04mB/CeqF2jPgfEJOvs6V6H0gJ+WIfajTuYy4KhFisv5OyZdh173Zha9KA==, tarball: https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.0.32.tgz}
+    resolution: {integrity: sha512-RfktqFS8IU9TlYwZijWoQqW2oXYW04mB/CeqF2jPgfEJOvs6V6H0gJ+WIfajTuYy4KhFisv5OyZdh173Zha9KA==}
     peerDependencies:
       '@deck.gl/core': ^9.0.0
       '@luma.gl/core': ~9.0.0
@@ -214,145 +217,145 @@ packages:
       react-dom: '>=16.3.0'
 
   '@esbuild/aix-ppc64@0.23.1':
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz}
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.23.1':
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.23.1':
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz}
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.23.1':
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.23.1':
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.23.1':
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.23.1':
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.23.1':
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.23.1':
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.23.1':
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz}
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.23.1':
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz}
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.23.1':
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz}
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.23.1':
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz}
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.23.1':
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz}
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.23.1':
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz}
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.23.1':
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz}
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.23.1':
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.23.1':
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/sunos-x64@0.23.1':
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.23.1':
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz}
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.23.1':
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz}
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.23.1':
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz}
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -623,55 +626,55 @@ packages:
     resolution: {integrity: sha512-n4zYNLSyCo0Ln5b7qxqQeQ34OZKXwgbdcx6kmkQbywr+0k6M3Vinft0T72R6CDAcDrne2IAgSud4uWCzFgc5HA==}
 
   '@next/swc-darwin-arm64@14.1.4':
-    resolution: {integrity: sha512-ubmUkbmW65nIAOmoxT1IROZdmmJMmdYvXIe8211send9ZYJu+SqxSnJM4TrPj9wmL6g9Atvj0S/2cFmMSS99jg==, tarball: https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.4.tgz}
+    resolution: {integrity: sha512-ubmUkbmW65nIAOmoxT1IROZdmmJMmdYvXIe8211send9ZYJu+SqxSnJM4TrPj9wmL6g9Atvj0S/2cFmMSS99jg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
   '@next/swc-darwin-x64@14.1.4':
-    resolution: {integrity: sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==, tarball: https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.4.tgz}
+    resolution: {integrity: sha512-b0Xo1ELj3u7IkZWAKcJPJEhBop117U78l70nfoQGo4xUSvv0PJSTaV4U9xQBLvZlnjsYkc8RwQN1HoH/oQmLlQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
   '@next/swc-linux-arm64-gnu@14.1.4':
-    resolution: {integrity: sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==, tarball: https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.4.tgz}
+    resolution: {integrity: sha512-457G0hcLrdYA/u1O2XkRMsDKId5VKe3uKPvrKVOyuARa6nXrdhJOOYU9hkKKyQTMru1B8qEP78IAhf/1XnVqKA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
   '@next/swc-linux-arm64-musl@14.1.4':
-    resolution: {integrity: sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==, tarball: https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.4.tgz}
+    resolution: {integrity: sha512-l/kMG+z6MB+fKA9KdtyprkTQ1ihlJcBh66cf0HvqGP+rXBbOXX0dpJatjZbHeunvEHoBBS69GYQG5ry78JMy3g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
   '@next/swc-linux-x64-gnu@14.1.4':
-    resolution: {integrity: sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==, tarball: https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.4.tgz}
+    resolution: {integrity: sha512-BapIFZ3ZRnvQ1uWbmqEGJuPT9cgLwvKtxhK/L2t4QYO7l+/DxXuIGjvp1x8rvfa/x1FFSsipERZK70pewbtJtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
   '@next/swc-linux-x64-musl@14.1.4':
-    resolution: {integrity: sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==, tarball: https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.4.tgz}
+    resolution: {integrity: sha512-mqVxTwk4XuBl49qn2A5UmzFImoL1iLm0KQQwtdRJRKl21ylQwwGCxJtIYo2rbfkZHoSKlh/YgztY0qH3wG1xIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
   '@next/swc-win32-arm64-msvc@14.1.4':
-    resolution: {integrity: sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==, tarball: https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.4.tgz}
+    resolution: {integrity: sha512-xzxF4ErcumXjO2Pvg/wVGrtr9QQJLk3IyQX1ddAC/fi6/5jZCZ9xpuL9Tzc4KPWMFq8GGWFVDMshZOdHGdkvag==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
   '@next/swc-win32-ia32-msvc@14.1.4':
-    resolution: {integrity: sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==, tarball: https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.4.tgz}
+    resolution: {integrity: sha512-WZiz8OdbkpRw6/IU/lredZWKKZopUMhcI2F+XiMAcPja0uZYdMTZQRoQ0WZcvinn9xZAidimE7tN9W5v9Yyfyw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@14.1.4':
-    resolution: {integrity: sha512-4Rto21sPfw555sZ/XNLqfxDUNeLhNYGO2dlPqsnuCg8N8a2a9u1ltqBOPQ4vj1Gf7eJC0W2hHG2eYUHuiXgY2w==, tarball: https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.4.tgz}
+    resolution: {integrity: sha512-4Rto21sPfw555sZ/XNLqfxDUNeLhNYGO2dlPqsnuCg8N8a2a9u1ltqBOPQ4vj1Gf7eJC0W2hHG2eYUHuiXgY2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1190,7 +1193,7 @@ packages:
       react-dom: '>= 16.8'
 
   '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
   '@pkgr/core@0.1.1':
@@ -2259,7 +2262,7 @@ packages:
     engines: {node: '>=8'}
 
   brotli@1.3.3:
-    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==, tarball: https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz}
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
   browserslist@4.24.0:
     resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
@@ -2667,7 +2670,7 @@ packages:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding@0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==, tarball: https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz}
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2968,7 +2971,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -3477,7 +3480,7 @@ packages:
     engines: {node: '>=10'}
 
   lz4js@0.2.0:
-    resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==, tarball: https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz}
+    resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
 
   lzo-wasm@0.0.4:
     resolution: {integrity: sha512-VKlnoJRFrB8SdJhlVKvW5vI1gGwcZ+mvChEXcSX6r2xDNc/Q2FD9esfBmGCuPZdrJ1feO+YcVFd2PTk0c137Gw==}
@@ -3591,7 +3594,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   next-plausible@3.12.3:
-    resolution: {integrity: sha512-kRtapWHHvEz/qAD9JXBPieq6+CNOqSDuiMlRegVzJBWna3l6VhCvfZGphAcBHyAnWEJ9RXcHtRMmq3FwHKz2Aw==, tarball: https://registry.npmjs.org/next-plausible/-/next-plausible-3.12.3.tgz}
+    resolution: {integrity: sha512-kRtapWHHvEz/qAD9JXBPieq6+CNOqSDuiMlRegVzJBWna3l6VhCvfZGphAcBHyAnWEJ9RXcHtRMmq3FwHKz2Aw==}
     peerDependencies:
       next: '^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 '
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3620,7 +3623,7 @@ packages:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-gyp@8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==, tarball: https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz}
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
     engines: {node: '>= 10.12.0'}
     hasBin: true
 
@@ -3699,6 +3702,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4473,7 +4480,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
   wrap-ansi@8.1.0:
@@ -4498,12 +4505,16 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yocto-queue@1.1.1:
+    resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
+    engines: {node: '>=12.20'}
+
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
   zstd-codec@0.1.5:
-    resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==, tarball: https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.5.tgz}
+    resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
 
 snapshots:
 
@@ -8267,7 +8278,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -8280,7 +8291,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8302,7 +8313,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9353,6 +9364,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.1.1
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -10238,6 +10253,8 @@ snapshots:
   yaml@2.5.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.1.1: {}
 
   yoctocolors@2.1.1: {}
 

--- a/prisma/migrations/20250110091927_add_flow_types/migration.sql
+++ b/prisma/migrations/20250110091927_add_flow_types/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `Flow` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "FlowType" AS ENUM ('SEA_DOMESTIC', 'SEA_REEXPORT', 'LAND_DOMESTIC', 'LAND_REEXPORT', 'WITHIN_COUNTRY');
+
+-- DropForeignKey
+ALTER TABLE "Flow" DROP CONSTRAINT "Flow_foodGroupId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FlowSegment" DROP CONSTRAINT "FlowSegment_flowId_fkey";
+
+-- AlterTable
+ALTER TABLE "Flow" ADD COLUMN     "type" "FlowType" NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Flow" ADD CONSTRAINT "Flow_foodGroupId_fkey" FOREIGN KEY ("foodGroupId") REFERENCES "FoodGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FlowSegment" ADD CONSTRAINT "FlowSegment_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "Flow"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250120074633_change_edges_id/migration.sql
+++ b/prisma/migrations/20250120074633_change_edges_id/migration.sql
@@ -1,0 +1,59 @@
+-- Drop existing materialized view
+DROP MATERIALIZED VIEW IF EXISTS "EdgeFlowAggregation";
+
+/*
+  Warnings:
+
+  - The primary key for the `Edge` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `Edge` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Added the required column `id_str` to the `Edge` table without a default value. This is not possible if the table is not empty.
+  - Changed the type of `edgeId` on the `FlowSegmentEdges` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "FlowSegmentEdges" DROP CONSTRAINT "FlowSegmentEdges_edgeId_fkey";
+
+-- AlterTable
+ALTER TABLE "Edge" DROP CONSTRAINT "Edge_pkey",
+ADD COLUMN     "id_str" TEXT NOT NULL,
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "Edge_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "FlowSegmentEdges" DROP COLUMN "edgeId",
+ADD COLUMN     "edgeId" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "FlowSegmentEdges_edgeId_idx" ON "FlowSegmentEdges"("edgeId");
+
+-- AddForeignKey
+ALTER TABLE "FlowSegmentEdges" ADD CONSTRAINT "FlowSegmentEdges_edgeId_fkey" FOREIGN KEY ("edgeId") REFERENCES "Edge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateMaterializedView
+CREATE MATERIALIZED VIEW "EdgeFlowAggregation" AS
+SELECT
+  e.id AS "edgeId",
+  f."foodGroupId",
+  COUNT(DISTINCT fs.id) AS "flowCount",
+  SUM(f.value) AS "flowSum"
+FROM
+  "Edge" e
+  INNER JOIN "FlowSegmentEdges" fse ON e.id = fse."edgeId"
+  INNER JOIN "FlowSegment" fs ON fse."flowSegmentId" = fs.id
+  INNER JOIN "Flow" f ON fs."flowId" = f.id
+GROUP BY
+  e.id, f."foodGroupId"
+HAVING
+  COUNT(DISTINCT fs.id) > 0;
+
+-- CreateIndex
+CREATE INDEX "EdgeFlowAggregation_edgeId_foodGroupId_idx" ON "EdgeFlowAggregation"("edgeId", "foodGroupId");
+
+-- CreateFunction
+CREATE OR REPLACE FUNCTION refresh_edge_flow_aggregation()
+RETURNS void AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW "EdgeFlowAggregation";
+END;
+$$ LANGUAGE plpgsql;

--- a/prisma/migrations/20250120103412_add_road_node/migration.sql
+++ b/prisma/migrations/20250120103412_add_road_node/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NodeType" ADD VALUE 'ROAD';

--- a/prisma/migrations/20250122192800_use_numeric_primary_keys/migration.sql
+++ b/prisma/migrations/20250122192800_use_numeric_primary_keys/migration.sql
@@ -1,0 +1,48 @@
+DROP MATERIALIZED VIEW IF EXISTS "EdgeFlowAggregation";
+
+/*
+  Warnings:
+
+  - The primary key for the `Flow` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `FlowSegment` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `id` on the `Flow` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `id` on the `FlowSegment` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `flowId` on the `FlowSegment` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `flowSegmentId` on the `FlowSegmentEdges` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "FlowSegment" DROP CONSTRAINT "FlowSegment_flowId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "FlowSegmentEdges" DROP CONSTRAINT "FlowSegmentEdges_flowSegmentId_fkey";
+
+-- AlterTable
+ALTER TABLE "Flow" DROP CONSTRAINT "Flow_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" BIGINT NOT NULL,
+ADD CONSTRAINT "Flow_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "FlowSegment" DROP CONSTRAINT "FlowSegment_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" BIGINT NOT NULL,
+DROP COLUMN "flowId",
+ADD COLUMN     "flowId" BIGINT NOT NULL,
+ADD CONSTRAINT "FlowSegment_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "FlowSegmentEdges" DROP COLUMN "flowSegmentId",
+ADD COLUMN     "flowSegmentId" BIGINT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "flow_segment_composite_idx" ON "FlowSegment"("flowId", "order");
+
+-- CreateIndex
+CREATE INDEX "FlowSegmentEdges_flowSegmentId_idx" ON "FlowSegmentEdges"("flowSegmentId");
+
+-- AddForeignKey
+ALTER TABLE "FlowSegment" ADD CONSTRAINT "FlowSegment_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "Flow"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FlowSegmentEdges" ADD CONSTRAINT "FlowSegmentEdges_flowSegmentId_fkey" FOREIGN KEY ("flowSegmentId") REFERENCES "FlowSegment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250128160938_change_flow_segment_edge_id_type/migration.sql
+++ b/prisma/migrations/20250128160938_change_flow_segment_edge_id_type/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "FlowSegmentEdges" DROP CONSTRAINT "FlowSegmentEdges_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "FlowSegmentEdges_pkey" PRIMARY KEY ("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,7 +75,7 @@ enum FlowType {
 }
 
 model Flow {
-  id          String        @id
+  id          BigInt        @id
   fromArea    Area          @relation("FromArea", fields: [fromAreaId], references: [id])
   fromAreaId  String
   toArea      Area          @relation("ToArea", fields: [toAreaId], references: [id])
@@ -88,9 +88,9 @@ model Flow {
 }
 
 model FlowSegment {
-  id     String             @id
+  id     BigInt             @id
   mode   String
-  flowId String
+  flowId BigInt
   flow   Flow               @relation(fields: [flowId], references: [id], onDelete: Cascade)
   edges  FlowSegmentEdges[]
 
@@ -103,7 +103,7 @@ model FlowSegmentEdges {
   id            Int         @id @default(autoincrement())
   edgeId        Int
   edge          Edge        @relation(fields: [edgeId], references: [id])
-  flowSegmentId String
+  flowSegmentId BigInt
   flowSegment   FlowSegment @relation(fields: [flowSegmentId], references: [id])
   order         Int
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ enum NodeType {
   PORT
   RAIL_STATION
   ADMIN
+  ROAD
 }
 
 model Node {
@@ -48,7 +49,8 @@ enum EdgeType {
 }
 
 model Edge {
-  id           String                                         @id
+  id           Int                                            @id @default(autoincrement())
+  id_str       String
   distance     Float
   type         EdgeType
   geom         Unsupported("geometry(MultiLineString, 3857)")
@@ -99,7 +101,7 @@ model FlowSegment {
 
 model FlowSegmentEdges {
   id            Int         @id @default(autoincrement())
-  edgeId        String
+  edgeId        Int
   edge          Edge        @relation(fields: [edgeId], references: [id])
   flowSegmentId String
   flowSegment   FlowSegment @relation(fields: [flowSegmentId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,14 @@ model Edge {
   @@index([fromNodeId, toNodeId])
 }
 
+enum FlowType {
+  SEA_DOMESTIC
+  SEA_REEXPORT
+  LAND_DOMESTIC
+  LAND_REEXPORT
+  WITHIN_COUNTRY
+}
+
 model Flow {
   id          String        @id
   fromArea    Area          @relation("FromArea", fields: [fromAreaId], references: [id])
@@ -71,7 +79,8 @@ model Flow {
   toArea      Area          @relation("ToArea", fields: [toAreaId], references: [id])
   toAreaId    String
   foodGroupId Int
-  foodGroup   FoodGroup     @relation(fields: [foodGroupId], references: [id])
+  foodGroup   FoodGroup     @relation(fields: [foodGroupId], references: [id], onDelete: Cascade)
+  type        FlowType
   value       Float
   FlowSegment FlowSegment[]
 }
@@ -80,7 +89,7 @@ model FlowSegment {
   id     String             @id
   mode   String
   flowId String
-  flow   Flow               @relation(fields: [flowId], references: [id])
+  flow   Flow               @relation(fields: [flowId], references: [id], onDelete: Cascade)
   edges  FlowSegmentEdges[]
 
   order Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,7 @@ model FlowSegment {
 }
 
 model FlowSegmentEdges {
-  id            Int         @id @default(autoincrement())
+  id            BigInt      @id @default(autoincrement())
   edgeId        Int
   edge          Edge        @relation(fields: [edgeId], references: [id])
   flowSegmentId BigInt

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -36,6 +36,13 @@ export const INLAND_PORTS_PATH = path.join(
   `IWWNodes_infrastructure.gpkg`
 );
 export const INLAND_PORTS_TABLENAME = "IWWNodes_infrastructure";
+
+export const ROAD_NODES_CSV_PATH = path.join(
+  INFRASTRUCTURE_DATA_PATH,
+  `RoadNodes_infrastructure.csv`
+);
+export const ROAD_NODES_TABLENAME = "RoadNodes_infrastructure";
+
 export const RAIL_STATIONS_PATH = path.join(
   INFRASTRUCTURE_DATA_PATH,
   `RailNodes_infrastructure.gpkg`

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -9,48 +9,59 @@ export const SEED_DATA_PATH = path.resolve(
   process.env.SEED_DATA_PATH as string
 );
 
+const DEMOGRAPHIC_DATA_PATH = path.join(SEED_DATA_PATH, "Demographic Data");
+const INFRASTRUCTURE_DATA_PATH = path.join(SEED_DATA_PATH, "Infrastructure");
+const MARITIME_INFRASTRUCTURE_DATA_PATH = path.join(
+  INFRASTRUCTURE_DATA_PATH,
+  "maritime"
+);
+
 export const ADMIN_CENTROIDS_PATH = path.join(
-  SEED_DATA_PATH,
+  DEMOGRAPHIC_DATA_PATH,
   "admin_centroids.gpkg"
 );
 export const ADMIN_LIMITS_PATH = path.join(
-  SEED_DATA_PATH,
+  DEMOGRAPHIC_DATA_PATH,
   "admin_polygons.gpkg"
 );
 export const ADMIN_LIMITS_TABLENAME = "admin_polygons";
 
 export const ADMIN_INDICATORS_PATH = path.join(
-  SEED_DATA_PATH,
+  DEMOGRAPHIC_DATA_PATH,
   "demographics_economics_by_admin1region.csv"
 );
 
 export const INLAND_PORTS_PATH = path.join(
-  SEED_DATA_PATH,
+  INFRASTRUCTURE_DATA_PATH,
   `IWWNodes_infrastructure.gpkg`
 );
 export const INLAND_PORTS_TABLENAME = "IWWNodes_infrastructure";
 export const RAIL_STATIONS_PATH = path.join(
-  SEED_DATA_PATH,
+  INFRASTRUCTURE_DATA_PATH,
   `RailNodes_infrastructure.gpkg`
 );
 export const RAIL_STATIONS_TABLENAME = "RailNodes_infrastructure";
 export const NODES_MARITIME_FILE = "nodes_maritime.gpkg";
 export const NODES_MARITIME_TABLENAME = "nodes_maritime";
-export const NODES_PATH = path.join(SEED_DATA_PATH, NODES_MARITIME_FILE);
+export const NODES_MARITIME_PATH = path.join(
+  MARITIME_INFRASTRUCTURE_DATA_PATH,
+  NODES_MARITIME_FILE
+);
 
 export const EDGE_IDS_SQLITE_DB_PATH = path.join(SEED_DATA_PATH, "edges_id.db");
 export const EDGES_LAND_FILE = path.join(
-  SEED_DATA_PATH,
+  INFRASTRUCTURE_DATA_PATH,
   "Geometry_Landmapping_hexcode_complete.csv"
 );
 export const EDGES_LAND_FILE_TEMP = path.join(
   SEED_DATA_PATH,
   "edges_land_temp.csv"
 );
-export const EDGES_MARITIME_FILE = "edges_maritime_corrected.gpkg";
-export const EDGES_MARITIME_TABLENAME = "edges_maritime_corrected";
+
+export const EDGES_MARITIME_FILE = "edges_maritime_corrected_12172024.gpkg";
+export const EDGES_MARITIME_TABLENAME = "maritime_edges";
 export const EDGES_MARITIME_PATH = path.join(
-  SEED_DATA_PATH,
+  MARITIME_INFRASTRUCTURE_DATA_PATH,
   EDGES_MARITIME_FILE
 );
 

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -71,4 +71,4 @@ export const FOOD_GROUPS_LIST_FILE = path.join(
   "fg1_fg2_fg3_lookup.csv"
 );
 
-export const FLOWS_FOLDER = path.join(SEED_DATA_PATH, "Flows/Land_V2");
+export const FLOWS_FOLDER = path.join(SEED_DATA_PATH, "Flows");

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -67,7 +67,8 @@ export const EDGES_MARITIME_PATH = path.join(
 
 export const FOOD_GROUPS_LIST_FILE = path.join(
   SEED_DATA_PATH,
-  "Commodity/UniqueFG1_FG2.csv"
+  "Commodity",
+  "fg1_fg2_fg3_lookup.csv"
 );
 
 export const FLOWS_FOLDER = path.join(SEED_DATA_PATH, "Flows/Land_V2");

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -41,7 +41,6 @@ export const ROAD_NODES_CSV_PATH = path.join(
   INFRASTRUCTURE_DATA_PATH,
   `RoadNodes_infrastructure.csv`
 );
-export const ROAD_NODES_TABLENAME = "RoadNodes_infrastructure";
 
 export const RAIL_STATIONS_PATH = path.join(
   INFRASTRUCTURE_DATA_PATH,

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -455,7 +455,7 @@ async function createFlowSegmentEdgesIndexes(prisma: PrismaClient) {
   await prisma.$executeRaw`
     CREATE INDEX IF NOT EXISTS "FlowSegmentEdges_flowSegmentId_idx"
       ON public."FlowSegmentEdges" USING btree
-      ("flowSegmentId" COLLATE pg_catalog."default" ASC NULLS LAST)
+      ("flowSegmentId" ASC NULLS LAST)
       TABLESPACE pg_default;
   `;
 

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -142,9 +142,6 @@ async function ingestFlowFile(
     "Created temporary files for flows, flow segments and flow segments edges..."
   );
 
-  await cascadeDeleteFlows(prisma, foodGroup.id, foodGroup.name);
-  log(`Deleted existing flows for ${foodGroup.name}...`);
-
   // Create a table for the CSV data
   await memoryDb.exec(`
     DROP TABLE IF EXISTS data;

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -23,6 +23,10 @@ export function logFileIngest(message: Error | string) {
     message instanceof Error
       ? `${currentTimestamp}: ${message.stack}\n`
       : `${currentTimestamp}: ${message}\n`;
+  // eslint-disable-next-line no-console
+  console.log(logMessage);
+
+  // Log to file
   fs.appendFileSync(filesIngestLog, logMessage);
 }
 

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -176,9 +176,13 @@ async function ingestFlowFile(
         try {
           const flowId = `${row.from_id_admin}-${row.to_id_admin}-${foodGroup.id}`;
 
+          const csvRowSegmentOrder = row.path_num || row.segment_order;
+
+          const csvRowMode = row.mode || "default";
+
           const flowSegmentId = crypto
             .createHash("md5")
-            .update(`${flowId}-${row.mode}-${row.segment_order}`)
+            .update(`${flowId}-${csvRowMode}-${csvRowSegmentOrder}`)
             .digest("hex");
 
           const edgeId = `${row.from_id_admin}-${row.to_id_admin}`;
@@ -193,8 +197,8 @@ async function ingestFlowFile(
               row.from_id_admin,
               row.to_id_admin,
               parseFloat(row.flow_value),
-              row.mode,
-              parseInt(row.segment_order),
+              csvRowMode,
+              parseInt(csvRowSegmentOrder),
               row.paths?.replace(/['"[\]\s]/g, ""),
             ]
           );

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -14,13 +14,14 @@ import {
   SEED_DATA_PATH,
 } from "./config";
 
-const filesIngestLog = path.resolve(SEED_DATA_PATH, "file_ingest_log.txt");
-
 const BATCH_SIZE = 500;
-const WORKER_COUNT = 10;
+const WORKER_COUNT = 5;
+const TRANSACTION_TIMEOUT = 20 * 60 * 1000;
+const SKIP_FOOD_GROUPS = 0; // Skip food groups that have already been ingested
 
 const limit = pLimit(WORKER_COUNT);
 
+const filesIngestLog = path.resolve(SEED_DATA_PATH, "file_ingest_log.txt");
 export function logFileIngest(message: Error | string) {
   const currentTimestamp = new Date().toISOString();
   const logMessage =
@@ -86,7 +87,7 @@ export const ingestFlows = async (prisma: PrismaClient) => {
     orderBy: {
       name: "asc",
     },
-    skip: 4,
+    skip: SKIP_FOOD_GROUPS,
   });
 
   const allFlowFiles = (await listFilesRecursively(FLOWS_FOLDER)).filter(
@@ -366,7 +367,7 @@ async function ingestFlowFile(
             });
           },
           {
-            timeout: 5 * 60 * 1000,
+            timeout: TRANSACTION_TIMEOUT,
           }
         );
 
@@ -428,7 +429,7 @@ async function cascadeDeleteFlows(
       log(`Deleted Flows for ${foodGroupName}...`);
     },
     {
-      timeout: 5 * 60 * 1000,
+      timeout: TRANSACTION_TIMEOUT,
     }
   );
 

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -122,16 +122,20 @@ export const ingestFlows = async (prisma: PrismaClient) => {
       const filename = path.basename(filePath);
 
       // First normalize any special spaces to regular spaces
-      const normalizedFilename = filename.replace(/[\u00A0\s]+/g, " ").trim();
-      const normalizedFoodGroup = foodGroup.name
+      const normalizedFilename = filename
+        .replace("Flows_", "")
+        .replace(".csv.gz", "")
         .replace(/[\u00A0\s]+/g, " ")
+        .replace(/_/g, " ") // replace underscores with spaces
+        .trim();
+      const normalizedFoodGroup = foodGroup.name
+        .replace(/[\u00A0\s]+/g, " ") // Normalize spaces
         .trim();
 
-      // Then encode
       const encodedFilename = encodeURIComponent(normalizedFilename);
       const encodedFoodGroup = encodeURIComponent(normalizedFoodGroup);
 
-      return encodedFilename.includes(encodedFoodGroup);
+      return encodedFilename === encodedFoodGroup;
     });
 
     if (foodGroupFiles.length === 0) {

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -178,7 +178,7 @@ async function ingestFlowFile(
 
           const csvRowSegmentOrder = row.path_num || row.segment_order;
 
-          const csvRowMode = row.mode || "default";
+          const csvRowMode = row.mode || "unknown";
 
           const flowSegmentId = crypto
             .createHash("md5")

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -451,9 +451,10 @@ async function cascadeDeleteFlows(
   foodGroupId: number,
   foodGroupName: string
 ) {
-  await prisma.$transaction(async (tx) => {
-    // Delete FlowSegmentEdges
-    await tx.$executeRaw`
+  await prisma.$transaction(
+    async (tx) => {
+      // Delete FlowSegmentEdges
+      await tx.$executeRaw`
         DELETE FROM "FlowSegmentEdges"
         WHERE "flowSegmentId" IN (
           SELECT "FlowSegment".id
@@ -462,25 +463,29 @@ async function cascadeDeleteFlows(
           WHERE "Flow"."foodGroupId" = ${foodGroupId}
         )
       `;
-    log(`Deleted FlowSegmentEdges for ${foodGroupName}...`);
+      log(`Deleted FlowSegmentEdges for ${foodGroupName}...`);
 
-    // Delete FlowSegments
-    await tx.$executeRaw`
+      // Delete FlowSegments
+      await tx.$executeRaw`
         DELETE FROM "FlowSegment"
         WHERE "flowId" IN (
           SELECT id FROM "Flow"
           WHERE "foodGroupId" = ${foodGroupId}
         )
       `;
-    log(`Deleted FlowSegments for ${foodGroupName}...`);
+      log(`Deleted FlowSegments for ${foodGroupName}...`);
 
-    // Delete Flows
-    await tx.$executeRaw`
+      // Delete Flows
+      await tx.$executeRaw`
         DELETE FROM "Flow"
         WHERE "foodGroupId" = ${foodGroupId}
       `;
-    log(`Deleted Flows for ${foodGroupName}...`);
-  });
+      log(`Deleted Flows for ${foodGroupName}...`);
+    },
+    {
+      timeout: 5 * 60 * 1000,
+    }
+  );
 
   log(`Completed cascading delete for ${foodGroupName}`);
 }

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -15,6 +15,25 @@ import {
   SEED_DATA_PATH,
 } from "./config";
 
+const filesIngestLog = path.resolve(SEED_DATA_PATH, "file_ingest_log.txt");
+
+export function logFileIngest(message: Error | string) {
+  const currentTimestamp = new Date().toISOString();
+  const logMessage =
+    message instanceof Error
+      ? `${currentTimestamp}: ${message.stack}\n`
+      : `${currentTimestamp}: ${message}\n`;
+  fs.appendFileSync(filesIngestLog, logMessage);
+}
+
+enum FlowType {
+  SEA_DOMESTIC = "SEA_DOMESTIC",
+  SEA_REEXPORT = "SEA_REEXPORT",
+  LAND_DOMESTIC = "LAND_DOMESTIC",
+  LAND_REEXPORT = "LAND_REEXPORT",
+  WITHIN_COUNTRY = "WITHIN_COUNTRY",
+}
+
 interface FoodGroupFile {
   path: string;
   size: number;
@@ -87,12 +106,19 @@ export const ingestFlows = async (prisma: PrismaClient) => {
     // Process each file for this food group
     for (const filePath of foodGroupFiles) {
       log(`Ingesting flows for ${foodGroup.name} from ${filePath}...`);
-      // try {
-      await ingestFlowFile(prisma, {
-        path: filePath,
-        size: fs.statSync(filePath).size,
-        foodGroup,
-      });
+      try {
+        await ingestFlowFile(prisma, {
+          path: filePath,
+          size: fs.statSync(filePath).size,
+          foodGroup,
+        });
+        logFileIngest(`Ingested flows for ${foodGroup.name} from ${filePath}`);
+      } catch (error) {
+        logFileIngest(
+          `Error ingesting flows for ${foodGroup.name} from ${filePath}`
+        );
+        logFileIngest(error as Error);
+      }
     }
 
     log(`Completed ingestion for ${foodGroup.name}`);
@@ -107,6 +133,22 @@ async function ingestFlowFile(
   log(`Ingesting flows for ${foodGroup.id} - ${foodGroup.name}...`);
 
   let filePath = foodGroupFile.path;
+
+  let flowType: FlowType;
+
+  if (filePath.includes("Sea_Domestic")) {
+    flowType = FlowType.SEA_DOMESTIC;
+  } else if (filePath.includes("Sea_ReExports")) {
+    flowType = FlowType.SEA_REEXPORT;
+  } else if (filePath.includes("Land_Domestic")) {
+    flowType = FlowType.LAND_DOMESTIC;
+  } else if (filePath.includes("Land_ReExports")) {
+    flowType = FlowType.LAND_REEXPORT;
+  } else if (filePath.includes("Within_Country")) {
+    flowType = FlowType.WITHIN_COUNTRY;
+  } else {
+    throw new Error(`Unknown flow type for file ${filePath}`);
+  }
 
   if (filePath.endsWith(".gz")) {
     const expandedFilePath = foodGroupFile.path.replace(".gz", "");
@@ -174,7 +216,7 @@ async function ingestFlowFile(
       .pipe(parseStream)
       .on("data", async (row) => {
         try {
-          const flowId = `${row.from_id_admin}-${row.to_id_admin}-${foodGroup.id}`;
+          const flowId = `${row.from_id_admin}-${row.to_id_admin}-${foodGroup.id}-${flowType}`;
 
           const csvRowSegmentOrder = row.path_num || row.segment_order;
 
@@ -227,14 +269,14 @@ async function ingestFlowFile(
     const { flow_id, from_id_admin, to_id_admin, flow_value } = flow;
 
     await flowsTempFileWriteStream.write(
-      `${flow_id},${from_id_admin},${to_id_admin},${flow_value},${foodGroup.id}\n`
+      `${flow_id},${from_id_admin},${to_id_admin},${flow_value},${foodGroup.id},${flowType}\n`
     );
   }
 
   await flowsTempFileWriteStream.end();
   log(`Wrote flows to file ${flowsTempFile}...`);
 
-  const copyFlowsCommand = `COPY \\"Flow\\" ("id", \\"fromAreaId\\", \\"toAreaId\\", "value", \\"foodGroupId\\") FROM '${flowsTempFile}' WITH (FORMAT CSV, DELIMITER ',');`;
+  const copyFlowsCommand = `COPY \\"Flow\\" ("id", \\"fromAreaId\\", \\"toAreaId\\", "value", \\"foodGroupId\\", \\"type\\") FROM '${flowsTempFile}' WITH (FORMAT CSV, DELIMITER ',');`;
   await execa(
     `psql -d ${POSTGRES_CONNECTION_STRING} -c "${copyFlowsCommand}"`,
     {

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -97,14 +97,17 @@ export const ingestFlows = async (prisma: PrismaClient) => {
     }
   );
 
-  log("Clearing all flows...");
-  await prisma.$executeRaw`TRUNCATE "Flow" RESTART IDENTITY CASCADE`;
+  // log("Clearing all flows...");
+  // await prisma.$executeRaw`TRUNCATE "Flow" RESTART IDENTITY CASCADE`;
 
-  log(`Dropping indexes for FlowSegmentEdges`);
-  await dropFlowSegmentEdgesIndexes(prisma);
+  // log(`Dropping indexes for FlowSegmentEdges`);
+  // await dropFlowSegmentEdgesIndexes(prisma);
 
   // Process each food group
   for (const foodGroup of foodGroups) {
+    log(`Clearing flows for ${foodGroup.name}`);
+    await cascadeDeleteFoodGroupFlows(prisma, foodGroup.id, foodGroup.name);
+
     // Clear any expanded csv flow files from previous runs before starting
     const expandedCsvFlowFiles = (
       await listFilesRecursively(FLOWS_FOLDER)

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -474,6 +474,16 @@ async function createFlowSegmentEdgesIndexes(prisma: PrismaClient) {
       TABLESPACE pg_default;
   `;
 
+  await prisma.$executeRaw`
+    CREATE INDEX IF NOT EXISTS "Flow_foodGroupId_idx"
+    ON "Flow" ("foodGroupId");
+  `;
+
+  await prisma.$executeRaw`
+    CREATE INDEX IF NOT EXISTS "FlowSegment_flowId_idx"
+    ON "FlowSegment" ("flowId");
+  `;
+
   log("Indexes created for FlowSegmentEdges");
 }
 
@@ -485,6 +495,14 @@ async function dropFlowSegmentEdgesIndexes(prisma: PrismaClient) {
 
   await prisma.$executeRaw`
     DROP INDEX IF EXISTS public."FlowSegmentEdges_flowSegmentId_idx";
+  `;
+
+  await prisma.$executeRaw`
+    DROP INDEX IF EXISTS "Flow_foodGroupId_idx";
+  `;
+
+  await prisma.$executeRaw`
+    DROP INDEX IF EXISTS "FlowSegment_flowId_idx";
   `;
 
   log("Indexes dropped for FlowSegmentEdges");

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -216,7 +216,7 @@ async function ingestFlowFile(
       .pipe(parseStream)
       .on("data", async (row) => {
         try {
-          const flowId = `${row.from_id_admin}-${row.to_id_admin}-${foodGroup.id}-${flowType}`;
+          const flowId = `${row.from_id_admin}-${row.to_id_admin}-${foodGroup.id}-${flowType}-${row.flow_value}`;
 
           const csvRowSegmentOrder = row.path_num || row.segment_order;
 

--- a/prisma/seed/foodgroups.ts
+++ b/prisma/seed/foodgroups.ts
@@ -10,33 +10,52 @@ export const ingestFoodGroups = async (prisma: PrismaClient) => {
   await prisma.$executeRaw`
     CREATE TABLE "food_groups_temp" (
       id SERIAL PRIMARY KEY,
-      food_group TEXT,
-      food_subgroup TEXT
+      foodgroup1_code TEXT,
+      foodgroup1 TEXT,
+      foodgroup2 TEXT,
+      foodgroup2_code TEXT,
+      foodgroup3 TEXT
     )
   `;
-  const copyCommand = `\\copy food_groups_temp (food_group, food_subgroup) FROM '${FOOD_GROUPS_LIST_FILE}' DELIMITER ',' CSV HEADER;`;
+  const copyCommand = `\\copy food_groups_temp (foodgroup1_code,foodgroup1,foodgroup2,foodgroup2_code,foodgroup3) FROM '${FOOD_GROUPS_LIST_FILE}' DELIMITER ',' CSV HEADER;`;
   await execa(`psql -d ${POSTGRES_CONNECTION_STRING} -c "${copyCommand}"`, {
     shell: true,
   });
 
-  // Insert level 0 food groups
+  // Level 3
   await prisma.$executeRaw`
     INSERT INTO "FoodGroup" (name, level)
-    SELECT DISTINCT food_group, 0
+    SELECT DISTINCT foodgroup3, 3
     FROM "food_groups_temp"
   `;
 
-  // Insert level 1 food subgroups
+  // Level 2
   await prisma.$executeRaw`
     INSERT INTO "FoodGroup" (name, level, \"parentId\")
-    SELECT DISTINCT food_subgroup, 1, fg.id
+    SELECT DISTINCT foodgroup2, 2, fg.id
     FROM "food_groups_temp" fgt
-    JOIN "FoodGroup"  fg ON fg.name = fgt.food_group
+    JOIN "FoodGroup"  fg ON fg.name = fgt.foodgroup3
+  `;
+
+  // Level 1
+  await prisma.$executeRaw`
+    INSERT INTO "FoodGroup" (name, level, \"parentId\")
+    SELECT DISTINCT foodgroup1, 1, fg.id
+    FROM "food_groups_temp" fgt
+    JOIN "FoodGroup"  fg ON fg.name = fgt.foodgroup2
   `;
 
   await prisma.$executeRaw`
     UPDATE "FoodGroup"
-    SET "slug" = LOWER(REPLACE(name, ' ', '_'))
+    SET "slug" = REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        LOWER(
+          REGEXP_REPLACE(name, '[^a-zA-Z0-9\\s-]', '', 'g')
+        ),
+        '\\s+', '-', 'g'
+      ),
+      '-+', '-', 'g'
+    )
   `;
 
   await prisma.$executeRaw`DROP TABLE IF EXISTS "food_groups_temp"`;

--- a/prisma/seed/foodgroups.ts
+++ b/prisma/seed/foodgroups.ts
@@ -39,10 +39,10 @@ export const ingestFoodGroups = async (prisma: PrismaClient) => {
 
   // Level 1
   await prisma.$executeRaw`
-    INSERT INTO "FoodGroup" (name, level, \"parentId\")
-    SELECT DISTINCT foodgroup1, 1, fg.id
+    INSERT INTO "FoodGroup" (name, level, "parentId")
+    SELECT DISTINCT fgt.foodgroup1, 1, fg.id
     FROM "food_groups_temp" fgt
-    JOIN "FoodGroup"  fg ON fg.name = fgt.foodgroup2
+    JOIN "FoodGroup" fg ON fg.name = fgt.foodgroup2 AND fg.level = 2;
   `;
 
   await prisma.$executeRaw`

--- a/prisma/seed/nodes.ts
+++ b/prisma/seed/nodes.ts
@@ -8,7 +8,7 @@ import {
   INLAND_PORTS_PATH,
   INLAND_PORTS_TABLENAME,
   NODES_MARITIME_TABLENAME,
-  NODES_PATH,
+  NODES_MARITIME_PATH,
   RAIL_STATIONS_PATH,
   RAIL_STATIONS_TABLENAME,
 } from "./config";
@@ -119,7 +119,7 @@ export const ingestNodes = async (prisma: PrismaClient) => {
   log("Ingested rail nodes.");
 
   await runOgr2Ogr(
-    NODES_PATH,
+    NODES_MARITIME_PATH,
     `-nln Node -append -nlt POINT -lco GEOMETRY_NAME=geom -t_srs EPSG:3857 -sql "SELECT id, name, upper(infra) as type, geom as centroid FROM ${NODES_MARITIME_TABLENAME}"`
   );
   log(`Ingested maritime nodes.`);

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -88,11 +88,7 @@ export async function optimizeDb(prisma: PrismaClient) {
   await prisma.$executeRaw`SET random_page_cost = 1.1`;
 }
 
-export function generateShortId(input: string): string {
-  return crypto
-    .createHash("sha1")
-    .update(input)
-    .digest("base64")
-    .replace(/[/+=]/g, "") // Remove characters that are not URL-safe
-    .substring(0, 16); // Truncate to 16 characters
+export function generateNumericId(input: string): bigint {
+  const hash = crypto.createHash("sha256").update(input).digest("hex");
+  return BigInt("0x" + hash.slice(0, 15));
 }

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -1,5 +1,6 @@
 import fs from "fs-extra";
 import path from "path";
+import crypto from "crypto";
 import { PrismaClient } from "@prisma/client/extension";
 import { POSTGRES_CONNECTION_STRING } from "./config";
 
@@ -85,4 +86,13 @@ export async function optimizeDb(prisma: PrismaClient) {
   await prisma.$executeRaw`SET max_parallel_workers = 8`;
   await prisma.$executeRaw`SET log_min_duration_statement = 1000`;
   await prisma.$executeRaw`SET random_page_cost = 1.1`;
+}
+
+export function generateShortId(input: string): string {
+  return crypto
+    .createHash("sha1")
+    .update(input)
+    .digest("base64")
+    .replace(/[/+=]/g, "") // Remove characters that are not URL-safe
+    .substring(0, 16); // Truncate to 16 characters
 }

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -25,11 +25,16 @@ export function log(message: string) {
   lastTimestamp = currentTimestamp;
 }
 
-export async function runOgr2Ogr(...args: string[]): Promise<void> {
-  // Prisma doesn't like ESM imports, so we have to use CommonJS here
+export async function runOgr2Ogr(
+  filePath: string,
+  ...args: string[]
+): Promise<void> {
   const { execa } = await import("execa");
 
-  const command = `ogr2ogr -f "PostgreSQL" PG:${POSTGRES_CONNECTION_STRING} ${args.join(" ")}`;
+  // Escape the file path by wrapping it in quotes
+  const escapedPath = `"${filePath}"`;
+
+  const command = `ogr2ogr -f "PostgreSQL" PG:${POSTGRES_CONNECTION_STRING} ${escapedPath} ${args.join(" ")}`;
 
   await execa(command, { shell: true });
 }

--- a/prisma/tasks/aggregate-edges.js
+++ b/prisma/tasks/aggregate-edges.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-var-requires */
+require("dotenv-flow").config();
+
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+async function main() {
+  try {
+    await prisma.$executeRaw`
+      DROP MATERIALIZED VIEW IF EXISTS "EdgeFlowAggregation";
+    `;
+
+    await prisma.$executeRaw`
+      CREATE MATERIALIZED VIEW "EdgeFlowAggregation" AS
+        SELECT fse."edgeId", COUNT(fs."flowId") AS "flowCount", SUM(f.value) AS "flowSum"
+        FROM public."FlowSegmentEdges" fse
+        INNER JOIN public."FlowSegment" fs ON fse."flowSegmentId" = fs."id"
+        INNER JOIN public."Flow" f ON fs."flowId" = f."id"
+        GROUP BY fse."edgeId";
+    `;
+  } catch (e) {
+    console.error(e);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -88,16 +88,16 @@ const AreaPage = async ({
     prisma.foodGroup.findMany(),
     prisma.$queryRawUnsafe(`
       SELECT sum(value)
-        FROM "FlowSegment"
-        LEFT JOIN "Flow" ON "FlowSegment"."flowId" = "Flow"."id"
-        WHERE "flowId" like '%-${area.id}-%';
+        FROM "Flow"
+        WHERE "toAreaId" = '${area.id}'
+        GROUP BY "toAreaId";
     `),
     prisma.$queryRawUnsafe(
       `SELECT "mode", sum("value") as value, "toAreaId", "Node"."name", "Node"."type"
         FROM "FlowSegment"
         LEFT JOIN "Flow" ON "FlowSegment"."flowId" = "Flow"."id"
         LEFT JOIN "Node" ON "Flow"."toAreaId" = "Node"."id"
-        WHERE "flowId" LIKE '${area.id}-%' AND "order" = 1
+        WHERE "Flow"."fromAreaId" = '${area.id}' AND "order" = 1
         GROUP BY "toAreaId", "mode", "Node"."name", "Node"."type"
         ORDER BY value DESC;
     `
@@ -272,7 +272,7 @@ const AreaPage = async ({
                 decimalPlaces={0}
               />
               <Metric
-                label="Suplied to the region"
+                label="Supplied to the region"
                 value={(inBoundFlows as ImportSum[])[0].sum}
                 formatType="weight"
                 decimalPlaces={0}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Opening this PR for visibility on the work of ingesting the final version of the data. This is a work in progress.

Current changes on the ingest workflow:

- Added instruction on how to copy the files from the Drive folder locally
- Fixed new folder structure
- Fixed new food group file ingest
- Fixed `runOgr2Ogr` function to allow spaces in filenames

The next step is to try to sucessfully ingest the smaller food group, which is Cloves. This process is failing now because the data files are separated by flow types, which is different from the previous approach. The mode is not included on the file as before. Header comparison:

- Previous: `from_id_admin,to_id_admin,flow_value,mode,segment_order,paths`
- Current: `from_id_admin,to_id_admin,flow_value,path_num,paths`

We need to clarify which mode should we assume for each file on the folder list:

- Flows/Land/Land_Domestic 
- Flows/Land/Land_ReExports
- Flows/Sea/Sea_Domestic 
- Flows/Land/Sea_ReExports
- Within_Country

cc @cameronkruse @kushankb @oliverroick @wrynearson