### PR TITLE
Optimize area loading

### DIFF
--- a/prisma/db-dump.js
+++ b/prisma/db-dump.js
@@ -26,6 +26,7 @@ const dumpDb = async () => {
       `pg_dump --format=c --no-owner --no-acl -f ${dumpFilePath} ${DATABASE_URL}`,
       {
         shell: true,
+        stdio: "inherit",
       }
     );
     console.log(`Database dump completed: ${dumpFilePath}`);

--- a/src/app/(home)/area/[areaId]/layout.tsx
+++ b/src/app/(home)/area/[areaId]/layout.tsx
@@ -1,0 +1,15 @@
+export default function Layout({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`w-[480px] bg-white h-screen grid grid-rows-[max-content_1fr] ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/(home)/area/[areaId]/loading.tsx
+++ b/src/app/(home)/area/[areaId]/loading.tsx
@@ -1,0 +1,40 @@
+import { PageHeaderSkeleton } from "@/app/components/page-header";
+import Layout from "./layout";
+import { PageSection } from "@/app/components/page-section";
+import { EAreaViewType } from "@/app/components/map/state/machine";
+import { MetricRow, SkeletonMetric } from "@/app/components/metric";
+import { Skeleton } from "@nextui-org/react";
+
+export default function Loading() {
+  return (
+    <Layout className="overflow-hidden">
+      <PageHeaderSkeleton />
+      <PageSection id={EAreaViewType.production}>
+        <div className="flex items-center text-neutral-700 mb-8">
+          <Skeleton className="w-36 h-8 rounded-lg" />
+        </div>
+        <MetricRow>
+          <SkeletonMetric />
+          <SkeletonMetric />
+          <SkeletonMetric />
+        </MetricRow>
+        <MetricRow>
+          <SkeletonMetric />
+          <SkeletonMetric />
+        </MetricRow>
+
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+        <Skeleton className="w-full h-12 rounded-lg my-4" />
+      </PageSection>
+    </Layout>
+  );
+}

--- a/src/app/components/metric.tsx
+++ b/src/app/components/metric.tsx
@@ -41,4 +41,12 @@ export const Metric: React.FC<MetricProps> = ({
   );
 };
 
+export const SkeletonMetric: React.FC = () => {
+  return (
+    <div className="flex flex-col text-center text-ink px-4 [&:not(:last-child)]:border-r-1 border-neutral-200">
+      <div className="w-20 h-20 bg-neutral-200 rounded-lg mb-1" />
+    </div>
+  );
+};
+
 export default Metric;

--- a/src/app/components/page-header.tsx
+++ b/src/app/components/page-header.tsx
@@ -36,4 +36,19 @@ function PageHeader({ title, itemType }: IPageHeader) {
   );
 }
 
+export function PageHeaderSkeleton() {
+  return (
+    <div className="bg-neutral-900 p-4 flex gap-4 items-start">
+      <div className="flex-grow">
+        <div className="flex items-center gap-2 mb-4">
+          <div className="w-8 h-8 bg-neutral-800 rounded-full" />
+          <div className="w-16 h-4 bg-neutral-800 rounded-full" />
+        </div>
+        <div className="w-48 h-9 rounded-full bg-neutral-800" />
+      </div>
+      <div className="w-6 h-rounded-full bg-neutral-800" />
+    </div>
+  );
+}
+
 export default PageHeader;


### PR DESCRIPTION
Currently, after click on area on the map, the URL change take some time to happen and the previous area doesn't go away when data is loading.

![loading-state-before](https://github.com/user-attachments/assets/44745fe7-1c0c-48da-b161-1a14af67a102)


In this PR we add a loading state, making the URL to change faster and a placeholder skeleton to be displayed while the data is loading.

![loading-state-after](https://github.com/user-attachments/assets/145e3f01-fed3-4837-8de4-cef27a71880f)

I also disabled the transportation section in this PR as the Sankey chart is not displaying the correct data and needs to be worked in separate.

cc @oliverroick @wrynearson @cameronkruse 