### PR TITLE
Fix build error of #99

### DIFF
--- a/src/app/(home)/area/[areaId]/layout.tsx
+++ b/src/app/(home)/area/[areaId]/layout.tsx
@@ -1,15 +1,11 @@
-export default function Layout({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
+const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div
-      className={`w-[480px] bg-white h-screen grid grid-rows-[max-content_1fr] ${className}`}
+      className={`w-[480px] bg-white h-screen grid grid-rows-[max-content_1fr] overflow-hidden`}
     >
       {children}
     </div>
   );
-}
+};
+
+export default Layout;

--- a/src/app/(home)/area/[areaId]/loading.tsx
+++ b/src/app/(home)/area/[areaId]/loading.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@nextui-org/react";
 
 export default function Loading() {
   return (
-    <Layout className="overflow-hidden">
+    <Layout>
       <PageHeaderSkeleton />
       <PageSection id={EAreaViewType.production}>
         <div className="flex items-center text-neutral-700 mb-8">

--- a/src/app/components/page-header.tsx
+++ b/src/app/components/page-header.tsx
@@ -46,7 +46,7 @@ export function PageHeaderSkeleton() {
         </div>
         <div className="w-48 h-9 rounded-full bg-neutral-800" />
       </div>
-      <div className="w-6 h-rounded-full bg-neutral-800" />
+      <div className="w-7 h-7 rounded-full bg-neutral-800" />
     </div>
   );
 }


### PR DESCRIPTION
In #99 we introduced a layout component for the area page that do not follow the expected interface fro Next.js. This removes the classname property and replace it with a `overflow-hidden` class in the component. This also fixes the skeleton button in the page header.