### PR TITLE
Fix destination area highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,5 @@
     "overrides": {
       "npm-run-path": "5.3.0"
     }
-  },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
     "overrides": {
       "npm-run-path": "5.3.0"
     }
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }

--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -13,6 +13,8 @@ import { EAreaViewType } from "@/app/components/map/state/machine";
 import { Button } from "@nextui-org/react";
 import Link from "next/link";
 
+import { FoodGroupColors } from "../../../../../tailwind.config";
+
 const SANKEY_LINKS_COUNT = 5;
 const SANKEY_HEIGHT = 600;
 const SANKEY_WIDTH = 435;
@@ -358,9 +360,12 @@ const AreaPage = async ({
             <ListBars
               showPercentage
               formatType="weight"
-              data={Object.values(foodGroupAgg).map(({ name, sum }) => ({
+              data={Object.values(foodGroupAgg).map(({ name, sum, slug }) => ({
                 label: name,
                 value: sum,
+                color: slug
+                  ? FoodGroupColors[slug as keyof typeof FoodGroupColors]
+                  : undefined,
               }))}
             />
           </PageSection>

--- a/src/app/components/map-popup.tsx
+++ b/src/app/components/map-popup.tsx
@@ -10,9 +10,22 @@ export interface IMapPopup {
   itemType: EItemType;
   longitude: number;
   latitude: number;
+  colorScheme?: "light" | "dark";
 }
 
-function MapPopup({ id, label, itemType, longitude, latitude }: IMapPopup) {
+function MapPopup({
+  id,
+  label,
+  itemType,
+  longitude,
+  latitude,
+  colorScheme = "light",
+}: IMapPopup) {
+  const colorClasses =
+    colorScheme === "light"
+      ? "bg-white text-neutral-800"
+      : "bg-neutral-800 text-white";
+
   return (
     <Popup
       key={id}
@@ -23,7 +36,9 @@ function MapPopup({ id, label, itemType, longitude, latitude }: IMapPopup) {
       closeButton={false}
       offset={12}
     >
-      <div className="flex gap-2 items-center font-header tracking-tighter text-white bg-neutral-800 p-2 rounded">
+      <div
+        className={`flex gap-2 items-center font-header tracking-tighter ${colorClasses} p-2 rounded`}
+      >
         <TypeIcon itemType={itemType} />
         <span>{label}</span>
       </div>

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -86,6 +86,12 @@ function GlobeInner() {
     });
   }, [actorRef]);
 
+  const handleZoomEnd = useCallback(() => {
+    actorRef.send({
+      type: "event:map:zoomend",
+    });
+  }, [actorRef]);
+
   useEffect(() => {
     actorRef.send({
       type: "event:page:mount",
@@ -154,6 +160,7 @@ function GlobeInner() {
         }}
         onMouseMove={eventHandlers.mousemove ? handleMouseMove : undefined}
         onMouseOut={eventHandlers.mousemove ? handleMouseOut : undefined}
+        onZoomEnd={eventHandlers.zoomEnd ? handleZoomEnd : undefined}
         style={{ width: "100%", height: "100%", flex: 1 }}
         mapStyle={mapboxStyleUrl}
       >

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -19,6 +19,7 @@ import AreaLayers from "./layers/areas";
 import PortsLayer from "./layers/ports";
 import { AREA_SOURCE_ID, AREA_VIEW_BOUNDS_PADDING } from "./constants";
 import DestinationAreasLayer from "./layers/destination-areas";
+import { EItemType } from "@/types/components";
 
 // Environment variables used in this component
 
@@ -71,6 +72,9 @@ function GlobeInner() {
   );
   const mapPopup = MachineContext.useSelector(
     (state) => state.context.mapPopup
+  );
+  const currentArea = MachineContext.useSelector(
+    (state) => state.context.currentArea
   );
 
   const handleMouseMove = useCallback((event: MapMouseEvent) => {
@@ -177,6 +181,16 @@ function GlobeInner() {
         <PortsLayer />
 
         {mapPopup && <MapPopup {...mapPopup} />}
+        {currentArea && (
+          <MapPopup
+            id={currentArea.id}
+            longitude={currentArea.centroid.coordinates[0]}
+            latitude={currentArea.centroid.coordinates[1]}
+            label={currentArea.name}
+            itemType={EItemType.area}
+            colorScheme="dark"
+          />
+        )}
       </Map>
     </div>
   );

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -171,9 +171,9 @@ function GlobeInner() {
         ></Source>
 
         <FoodGroupsLayer />
+        <EdgeLayer />
         <AreaLayers />
         <DestinationAreasLayer />
-        <EdgeLayer />
         <PortsLayer />
 
         {mapPopup && <MapPopup {...mapPopup} />}

--- a/src/app/components/map/legend/categories.tsx
+++ b/src/app/components/map/legend/categories.tsx
@@ -19,14 +19,14 @@ export default function CategoriesLegend() {
         <h3 className="mb-2 font-bold">Categories</h3>
         <div className="grid grid-cols-2 gap-x-8 gap-y-2">
           <LegendItem color="food-dairy-and-eggs" label="Dairy and Eggs" />
-          <LegendItem color="food-oils-and-oilseeds" label="Oils and Oilseed" />
-          <LegendItem color="food-starches" label="Starches" />
+          <LegendItem color="food-oils-and-oilseed" label="Oils and Oilseed" />
+          <LegendItem color="food-starchy-roots" label="Starchy Roots" />
           <LegendItem color="food-fruits" label="Fruits" />
           <LegendItem color="food-grains" label="Grains" />
           <LegendItem color="food-pulses" label="Pulses" />
           <LegendItem color="food-vegetables" label="Vegetables" />
           <LegendItem color="food-treenuts" label="Treenuts" />
-          <LegendItem color="food-meat-and-fish" label="Meet and Fish" />
+          <LegendItem color="food-meat-and-fish" label="Meat and Fish" />
           <LegendItem color="food-other" label="Other" />
         </div>
       </div>

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -615,9 +615,7 @@ export const globeViewMachine = createMachine(
           return {};
         }
 
-        const destinationAreaIds = destinationAreas
-          .slice(0, 6) // Only get the top 5 of destination area
-          .map(({ id }) => id);
+        const destinationAreaIds = destinationAreas.map(({ id }) => id);
 
         const destinationAreasFeatureIds = mapRef
           .querySourceFeatures(AREA_SOURCE_ID, {

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -47,6 +47,7 @@ interface StateContext {
   mapBounds: BBox | null;
   eventHandlers: {
     mousemove: boolean;
+    zoomEnd: boolean;
   };
 }
 
@@ -77,6 +78,7 @@ export const globeViewMachine = createMachine(
       mapBounds: null,
       eventHandlers: {
         mousemove: true,
+        zoomEnd: true,
       },
     },
 
@@ -222,6 +224,11 @@ export const globeViewMachine = createMachine(
           "event:map:mouseout": {
             target: "area:view:transportation",
             actions: "action:clearHighlightedArea",
+          },
+
+          "event:map:zoomend": {
+            target: "area:view:transportation",
+            actions: "action:applyDestinationAreaIdsToMap",
           },
         },
 
@@ -433,22 +440,10 @@ export const globeViewMachine = createMachine(
           );
         }
 
-        const destinationAreaIds = event.output.destinationAreas.map(
-          ({ id }) => id
-        );
-
-        const destinationAreasFeatureIds = mapRef
-          .querySourceFeatures(AREA_SOURCE_ID, {
-            filter: ["in", "id", ...destinationAreaIds],
-            sourceLayer: AREA_SOURCE_LAYER_ID,
-          })
-          .map((feature) => feature.id as number); // we are sure that the id is a number, because we are not using promoteId from MapboxGL
-
         return {
           currentArea: event.output,
           currentAreaFeature: feature,
           destinationAreas: event.output.destinationAreas,
-          destinationAreasFeatureIds,
         };
       }),
       "action:enterProductionAreaView": assign(({ context }) => {
@@ -614,11 +609,22 @@ export const globeViewMachine = createMachine(
         };
       }),
       "action:applyDestinationAreaIdsToMap": assign(({ context }) => {
-        const { mapRef, destinationAreasFeatureIds } = context;
+        const { mapRef, destinationAreas } = context;
 
         if (!mapRef) {
           return {};
         }
+
+        const destinationAreaIds = destinationAreas
+          .slice(0, 6) // Only get the top 5 of destination area
+          .map(({ id }) => id);
+
+        const destinationAreasFeatureIds = mapRef
+          .querySourceFeatures(AREA_SOURCE_ID, {
+            filter: ["in", "id", ...destinationAreaIds],
+            sourceLayer: AREA_SOURCE_LAYER_ID,
+          })
+          .map((feature) => feature.id as number); // we are sure that the id is a number, because we are not using promoteId from MapboxGL
 
         for (const destinationAreaFeatureId of destinationAreasFeatureIds) {
           mapRef.setFeatureState(
@@ -631,7 +637,9 @@ export const globeViewMachine = createMachine(
           );
         }
 
-        return {};
+        return {
+          destinationAreasFeatureIds,
+        };
       }),
       "action:fitMapToCurrentAreaBounds": assign(({ context }) => {
         const { mapRef, currentArea } = context;

--- a/src/app/components/map/state/types/events.ts
+++ b/src/app/components/map/state/types/events.ts
@@ -24,6 +24,10 @@ interface EventMapMouseOut {
   type: "event:map:mouseout";
 }
 
+interface EventMapZoomEnd {
+  type: "event:map:zoomend";
+}
+
 interface EventFetchAreaDone {
   type: "xstate.done.actor.0.globeView.area:fetching";
   input: {
@@ -51,6 +55,7 @@ export type StateEvents =
   | EventMapMouseMove
   | EventFetchAreaDone
   | EventMapMouseOut
+  | EventMapZoomEnd
   | EventAreaSelectFoodTransportation
   | EventAreaSelectImpact
   | EventAreaSelectFoodProduced;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,19 @@
 import type { Config } from "tailwindcss";
 import { nextui } from "@nextui-org/react";
 
+export const FoodGroupColors = {
+  "dairy-and-eggs": "#76B7B2",
+  "oils-and-oilseed": "#EDC948",
+  "starchy-roots": "#4E79A7",
+  fruits: "#FF9DA7",
+  grains: "#F28E2B",
+  pulses: "#B07AA1",
+  vegetables: "#59A14F",
+  treenuts: "#9C755F",
+  "meat-and-fish": "#E15759",
+  other: "#BAB0AC",
+};
+
 const config: Config = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -12,8 +25,9 @@ const config: Config = {
     "text-category-area",
     "text-category-route",
     "text-category-node",
-    "bg-food-oils-and-oilseeds",
-    "bg-food-starches",
+    "bg-food-oils-and-oilseed",
+    "bg-food-dairy-and-eggs",
+    "bg-food-starchy-roots",
     "bg-food-fruits",
     "bg-food-grains",
     "bg-food-pulses",
@@ -43,18 +57,7 @@ const config: Config = {
         route: "#99E2EE",
         node: "#FFD27A",
       },
-      food: {
-        "dairy-and-eggs": "#76B7B2",
-        "oils-and-oilseeds": "#EDC948",
-        starches: "#4E79A7",
-        fruits: "#FF9DA7",
-        grains: "#F28E2B",
-        pulses: "#B07AA1",
-        vegetables: "#59A14F",
-        treenuts: "#9C755F",
-        "meat-and-fish": "#E15759",
-        other: "#BAB0AC",
-      },
+      food: FoodGroupColors,
       neutral: {
         50: "#FAFAF9",
         100: "#F5F5F4",


### PR DESCRIPTION
This change addresses two things:

- Updates the destination-highlight when the map is zoomed
- Limit the destination-highlight to the top 5 areas by transportation volume

Changes added:

- Order the destination area data by flow value
- Move querying the feature IDs to the `applyDestinationAreaIdsToMap` action. That way we can query the feature IDs using the current map view
- Add a `zoomend` event that triggers the `applyDestinationAreaIdsToMap`