### PR TITLE
Pin Node version to 20.x

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 public-hoist-pattern[]=*@nextui-org/*
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "global",
   "version": "0.1.0",
   "private": true,
+  "engines" : {
+    "node" : ">=20.0.0 <21.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Enforce Node version to prevent unwanted automatic updates to package.json