### PR TITLE
Fix component layering using z-index

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -4,7 +4,7 @@ import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr";
 
 const Home = () => {
   return (
-    <div className="absolute right-4 top-4 z-40">
+    <div className="absolute right-4 top-4 z-20">
       <Button
         href="/search"
         as={Link}

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -143,7 +143,7 @@ function GlobeInner() {
   }, []);
 
   return (
-    <div className="w-full h-full relative flex-1">
+    <div className="w-full h-full relative flex-1 z-10">
       <Legend />
       <Map
         mapboxAccessToken={mapboxAccessToken}

--- a/src/app/components/map/legend/index.tsx
+++ b/src/app/components/map/legend/index.tsx
@@ -23,7 +23,7 @@ function Legend() {
 
   return (
     <div
-      className={`absolute left-1/2 translate-x-[-50%] bottom-4 z-50 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]`}
+      className={`absolute left-1/2 translate-x-[-50%] bottom-4 z-20 bg-neutral-100/60 rounded text-xs backdrop-blur w-[530px]`}
     >
       <button
         className={`flex gap-4 items-center px-4 py-2 w-[100%] bg-neutral-200/80 font-header text-xxs uppercase ${isExpanded ? "rounded-t" : "rounded"}`}


### PR DESCRIPTION
Fixes #111 

Adjust z-index for several components so the legend and search button are not visible when the menu is open: 

- z-10 for the map
- z-20 for the legend and search
- z-50 for the menu

