### PR TITLE
Update about page structure, text and style

### DIFF
--- a/src/app/components/map/legend/categories.tsx
+++ b/src/app/components/map/legend/categories.tsx
@@ -31,7 +31,7 @@ export default function CategoriesLegend() {
         </div>
       </div>
       <div className="p-4 flex-grow">
-        <h3 className="mb-2 font-bold">Calories production</h3>
+        <h3 className="mb-2 font-bold">Calorie production variance</h3>
         <div className="flex gap-4 items-center">
           <span>Low</span>
           <span className="border border-neutral-400 w-[4px] h-[4px] rounded-[2px]" />

--- a/src/app/components/menu.tsx
+++ b/src/app/components/menu.tsx
@@ -50,18 +50,18 @@ function Menu() {
                 <p className="text-md leading-7 mt-8">
                   Food Twin Map visualizes the complex network of food
                   production and distribution across the globe. The map shows:
-                  <ul className="list-disc pl-8 mt-8 space-y-1">
-                    <li>Where different food groups are produced</li>
-                    <li>
-                      How food travels between regions through various transport
-                      routes
-                    </li>
-                    <li>
-                      The nutritional impact on populations Key economic
-                      indicators related to agriculture
-                    </li>
-                  </ul>
                 </p>
+                <ul className="list-disc pl-8 mt-8 space-y-1">
+                  <li>Where different food groups are produced</li>
+                  <li>
+                    How food travels between regions through various transport
+                    routes
+                  </li>
+                  <li>
+                    The nutritional impact on populations Key economic
+                    indicators related to agriculture
+                  </li>
+                </ul>
                 <p className="text-md leading-7 mt-8">
                   The data is based on a model developed in collaboration by
                   Earth Genome and Better Planet Lab. This model incorporates
@@ -80,40 +80,38 @@ function Menu() {
                 <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
                   2. Interacting with the Map
                 </h2>
-                <p className="text-md leading-7 mt-8">
-                  <ul className="list-disc pl-8 mt-8 space-y-1">
+                <ul className="list-disc pl-8 mt-8 space-y-1">
+                  <li>
+                    Click on any region to see detailed information about food
+                    production, transportation routes, and impact.
+                  </li>
+                  <li>
+                    Navigate between views using the tab sections on area pages
+                    to see:
+                  </li>
+                  <ul className="list-disc pl-8">
                     <li>
-                      Click on any region to see detailed information about food
-                      production, transportation routes, and impact.
+                      <b>Food Produced:</b> Types and quantities of food groups
+                      produced in the area
                     </li>
                     <li>
-                      Navigate between views using the tab sections on area
-                      pages to see:
-                    </li>
-                    <ul className="list-disc pl-8">
-                      <li>
-                        <b>Food Produced:</b> Types and quantities of food
-                        groups produced in the area
-                      </li>
-                      <li>
-                        <b>Food Transportation:</b> How food moves between
-                        regions through different routes
-                      </li>
-                      <li>
-                        <b>Impact on People:</b> Nutritional values and
-                        population metrics
-                      </li>
-                    </ul>
-                    <li>
-                      Use the search button in the top right to find specific
-                      regions or food groups.
+                      <b>Food Transportation:</b> How food moves between regions
+                      through different routes
                     </li>
                     <li>
-                      Hover over map elements to see tooltip information about
-                      areas, ports, and transport routes.
+                      <b>Impact on People:</b> Nutritional values and population
+                      metrics
                     </li>
                   </ul>
-                </p>
+                  <li>
+                    Use the search button in the top right to find specific
+                    regions or food groups.
+                  </li>
+                  <li>
+                    Hover over map elements to see tooltip information about
+                    areas, ports, and transport routes.
+                  </li>
+                </ul>
                 <Button
                   onClick={() => setIsOpen(false)}
                   className="mt-8 font-header bg-accent-warm-400 text-white rounded"
@@ -128,28 +126,28 @@ function Menu() {
                 <p className="text-md leading-7 mt-8">
                   The Food Twin Map integrates multiple data sources to create a
                   comprehensive view of global food systems:
-                  <ul className="list-disc pl-8 mt-8 space-y-1">
-                    <li>
-                      <b>Food Groups:</b> Categorized into major groups
-                      including grains, fruits, vegetables, dairy, meat & fish,
-                      pulses, oils, and more.
-                    </li>
-                    <li>
-                      <b>Transportation Routes:</b> Shows how food moves via
-                      road, rail, and waterways between producing areas and
-                      destinations.
-                    </li>
-                    <li>
-                      <b>Impact Metrics:</b> Nutritional values (calories,
-                      protein, iron, vitamin A) and how they relate to
-                      population needs.
-                    </li>
-                    <li>
-                      <b>Economic Indicators:</b> GDP, agricultural sector
-                      contribution, and Human Development Index for context.
-                    </li>
-                  </ul>
                 </p>
+                <ul className="list-disc pl-8 mt-8 space-y-1">
+                  <li>
+                    <b>Food Groups:</b> Categorized into major groups including
+                    grains, fruits, vegetables, dairy, meat & fish, pulses,
+                    oils, and more.
+                  </li>
+                  <li>
+                    <b>Transportation Routes:</b> Shows how food moves via road,
+                    rail, and waterways between producing areas and
+                    destinations.
+                  </li>
+                  <li>
+                    <b>Impact Metrics:</b> Nutritional values (calories,
+                    protein, iron, vitamin A) and how they relate to population
+                    needs.
+                  </li>
+                  <li>
+                    <b>Economic Indicators:</b> GDP, agricultural sector
+                    contribution, and Human Development Index for context.
+                  </li>
+                </ul>
                 <p className="text-md mt-8">
                   The underlying flow model was developed using methodology that
                   estimates food movement patterns based on production capacity,

--- a/src/app/components/menu.tsx
+++ b/src/app/components/menu.tsx
@@ -43,14 +43,31 @@ function Menu() {
                 panel: "pt-8",
               }}
             >
-              <Tab key="flows" title="Food flows">
-                <p>
-                  Lorem ipsum dolor sit amet consectetur. Felis vulputate etiam
-                  cras odio cras tellus habitant urna sociis. Donec tristique
-                  etiam est venenatis pharetra et eu vel ipsum. Platea sed
-                  faucibus dictum in. Massa consectetur semper neque orci at in
-                  donec egestas posuere. Arcu enim vulputate accumsan vitae ac
-                  placerat vivamus platea pulvinar. Augue vel tellus at iaculis.
+              <Tab key="flows" title="Overview">
+                <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
+                  1. Understanding Global Food Flows
+                </h2>
+                <p className="text-md leading-7 mt-8">
+                  Food Twin Map visualizes the complex network of food
+                  production and distribution across the globe. The map shows:
+                  <ul className="list-disc pl-8 mt-8 space-y-1">
+                    <li>Where different food groups are produced</li>
+                    <li>
+                      How food travels between regions through various transport
+                      routes
+                    </li>
+                    <li>
+                      The nutritional impact on populations Key economic
+                      indicators related to agriculture
+                    </li>
+                  </ul>
+                </p>
+                <p className="text-md leading-7 mt-8">
+                  The data is based on a model developed in collaboration by
+                  Earth Genome and Better Planet Lab. This model incorporates
+                  agricultural production statistics, trade data, and
+                  transportation infrastructure to estimate global food flows.
+                  You can learn more about this model here.
                 </p>
                 <Button
                   onClick={() => setIsOpen(false)}
@@ -59,17 +76,79 @@ function Menu() {
                   Explore Food Flows
                 </Button>
               </Tab>
-              <Tab key="disruptions" title="Disruptions" isDisabled>
-                Disruptions
+              <Tab key="disruptions" title="How To Use">
+                <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
+                  2. Interacting with the Map
+                </h2>
+                <p className="text-md leading-7 mt-8">
+                  <ul className="list-disc pl-8 mt-8 space-y-1">
+                    <li>
+                      Click on any region to see detailed information about food
+                      production, transportation routes, and impact.
+                    </li>
+                    <li>
+                      Navigate between views using the tab sections on area
+                      pages to see:
+                    </li>
+                    <ul className="list-disc pl-8">
+                      <li>
+                        <b>Food Produced:</b> Types and quantities of food
+                        groups produced in the area
+                      </li>
+                      <li>
+                        <b>Food Transportation:</b> How food moves between
+                        regions through different routes
+                      </li>
+                      <li>
+                        <b>Impact on People:</b> Nutritional values and
+                        population metrics
+                      </li>
+                    </ul>
+                    <li>
+                      Use the search button in the top right to find specific
+                      regions or food groups.
+                    </li>
+                    <li>
+                      Hover over map elements to see tooltip information about
+                      areas, ports, and transport routes.
+                    </li>
+                  </ul>
+                </p>
               </Tab>
-              <Tab key="about" title="About">
-                <p>
-                  Lorem ipsum dolor sit amet consectetur. Felis vulputate etiam
-                  cras odio cras tellus habitant urna sociis. Donec tristique
-                  etiam est venenatis pharetra et eu vel ipsum. Platea sed
-                  faucibus dictum in. Massa consectetur semper neque orci at in
-                  donec egestas posuere. Arcu enim vulputate accumsan vitae ac
-                  placerat vivamus platea pulvinar. Augue vel tellus at iaculis.
+              <Tab key="about" title="Data and Insights">
+                <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
+                  3. Understanding the Data
+                </h2>
+                <p className="text-md leading-7 mt-8">
+                  The Food Twin Map integrates multiple data sources to create a
+                  comprehensive view of global food systems:
+                  <ul className="list-disc pl-8 mt-8 space-y-1">
+                    <li>
+                      <b>Food Groups:</b> Categorized into major groups
+                      including grains, fruits, vegetables, dairy, meat & fish,
+                      pulses, oils, and more.
+                    </li>
+                    <li>
+                      <b>Transportation Routes:</b> Shows how food moves via
+                      road, rail, and waterways between producing areas and
+                      destinations.
+                    </li>
+                    <li>
+                      <b>Impact Metrics:</b> Nutritional values (calories,
+                      protein, iron, vitamin A) and how they relate to
+                      population needs.
+                    </li>
+                    <li>
+                      <b>Economic Indicators:</b> GDP, agricultural sector
+                      contribution, and Human Development Index for context.
+                    </li>
+                  </ul>
+                </p>
+                <p className="text-md mt-8">
+                  The underlying flow model was developed using methodology that
+                  estimates food movement patterns based on production capacity,
+                  infrastructure, and trade relationships. You can learn more
+                  about the model here.
                 </p>
               </Tab>
             </Tabs>

--- a/src/app/components/menu.tsx
+++ b/src/app/components/menu.tsx
@@ -71,7 +71,7 @@ function Menu() {
                 </p>
                 <Button
                   onClick={() => setIsOpen(false)}
-                  className="mt-4 font-header bg-accent-warm-400 text-white rounded"
+                  className="mt-8 font-header bg-accent-warm-400 text-white rounded"
                 >
                   Explore Food Flows
                 </Button>
@@ -114,6 +114,12 @@ function Menu() {
                     </li>
                   </ul>
                 </p>
+                <Button
+                  onClick={() => setIsOpen(false)}
+                  className="mt-8 font-header bg-accent-warm-400 text-white rounded"
+                >
+                  Explore Food Flows
+                </Button>
               </Tab>
               <Tab key="data-insights" title="Data and Insights">
                 <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
@@ -150,6 +156,12 @@ function Menu() {
                   infrastructure, and trade relationships. You can learn more
                   about the model here.
                 </p>
+                <Button
+                  onClick={() => setIsOpen(false)}
+                  className="mt-8 font-header bg-accent-warm-400 text-white rounded"
+                >
+                  Explore Food Flows
+                </Button>
               </Tab>
             </Tabs>
           </div>

--- a/src/app/components/menu.tsx
+++ b/src/app/components/menu.tsx
@@ -15,11 +15,11 @@ function Menu() {
       className={`absolute top-0 ${leftPosition} bottom-0 z-50 flex transition-left overflow-hidden`}
     >
       <div
-        className="w-screen h-screen flex-shrink-0 flex gap-4 box-border bg-neutral-100/50 backdrop-blur"
+        className="w-screen h-screen flex-shrink-0 flex gap-4 box-border bg-neutral-100/50 backdrop-blur overflow-y-auto"
         aria-hidden={!isOpen}
       >
         <div className="flex-grow">
-          <div className="max-w-128 mx-auto pt-12">
+          <div className="max-w-128 mx-auto py-12">
             <Image
               src="/logos/landscape.svg"
               alt="Food Twin"
@@ -164,7 +164,7 @@ function Menu() {
             </Tabs>
           </div>
         </div>
-        <div className="border-l-1 border-ink/10 p-4 flex">
+        <div className="border-l-1 border-ink/10 p-4 flex sticky top-0">
           <div className="m-auto">
             <Button
               isIconOnly

--- a/src/app/components/menu.tsx
+++ b/src/app/components/menu.tsx
@@ -43,7 +43,7 @@ function Menu() {
                 panel: "pt-8",
               }}
             >
-              <Tab key="flows" title="Overview">
+              <Tab key="overview" title="Overview">
                 <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
                   1. Understanding Global Food Flows
                 </h2>
@@ -76,7 +76,7 @@ function Menu() {
                   Explore Food Flows
                 </Button>
               </Tab>
-              <Tab key="disruptions" title="How To Use">
+              <Tab key="how-to-use" title="How To Use">
                 <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
                   2. Interacting with the Map
                 </h2>
@@ -115,7 +115,7 @@ function Menu() {
                   </ul>
                 </p>
               </Tab>
-              <Tab key="about" title="Data and Insights">
+              <Tab key="data-insights" title="Data and Insights">
                 <h2 className="mt-8 font-header text-sm tracking-wide uppercase">
                   3. Understanding the Data
                 </h2>


### PR DESCRIPTION
Closes #110 

Adds content and updated structure to the about pane, using [text](https://docs.google.com/document/d/1h20mghvxhTM4wLRZarMr30sBkhS5L1QV10FtHUdukg4/edit?tab=t.0) from Earth Genome.

| Overview | How to use | Data |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/61302507-5280-4b03-bb3f-6cf00cbf30b8) | ![image](https://github.com/user-attachments/assets/93f67dc9-b4ce-4aff-bbab-ebb574921963) | ![image](https://github.com/user-attachments/assets/986d26c0-da99-440e-ac2c-5951371efd59) |

## To-do

- [ ] Add link to end of overview page text
- [ ] Add link to end of data page text