### PR TITLE
Fix build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,6 +6,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - nvm install
         - npm install -g pnpm
         - pnpm install
     build:


### PR DESCRIPTION
Changes:

- Added nvm step to amplify.yml, Amplify uses Node.js v18 by default and we need to use the version from .nvmrc
- Removed `indicators` variable that was not being used in the area page and breaking the build

@oliverroick I'll go ahead and merge this to unblock the production build, this is just a clean up.