### PR TITLE
Update flow styling

### DIFF
--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -52,7 +52,7 @@ export async function GET(
       "Flow"."fromAreaId" = ${id}
     ORDER BY
       "Flow"."value" DESC
-    LIMIT 100;
+    LIMIT 500;
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -12,13 +12,7 @@ interface FlowGeometryRow {
 interface FlowRow {
   fromAreaId: string;
   toAreaId: string;
-  value: number;
-  foodGroupId: number;
-  foodGroupSlug: string;
-  level2FoodGroupId: number | null;
-  level2FoodGroupSlug: string | null;
-  level3FoodGroupId: number | null;
-  level3FoodGroupSlug: string | null;
+  totalValue: number;
 }
 
 export interface FromToFlowsResponse {
@@ -36,23 +30,17 @@ export async function GET(
     SELECT
       "Flow"."fromAreaId",
       "Flow"."toAreaId",
-      "Flow"."value",
-      "Flow"."foodGroupId",
-      "FoodGroup"."slug" as "foodGroupSlug",
-      "Level2FoodGroup"."id" as "level2FoodGroupId",
-      "Level2FoodGroup"."slug" as "level2FoodGroupSlug",
-      "Level3FoodGroup"."id" as "level3FoodGroupId",
-      "Level3FoodGroup"."slug" as "level3FoodGroupSlug"
+      sum("Flow"."value") as "totalValue"
     FROM
       "Flow"
-      JOIN "FoodGroup" ON "Flow"."foodGroupId" = "FoodGroup"."id"
-      LEFT JOIN "FoodGroup" AS "Level2FoodGroup" ON "FoodGroup"."parentId" = "Level2FoodGroup"."id"
-      LEFT JOIN "FoodGroup" AS "Level3FoodGroup" ON "Level2FoodGroup"."parentId" = "Level3FoodGroup"."id"
     WHERE
       "Flow"."fromAreaId" = ${id}
+    GROUP BY
+      "Flow"."fromAreaId",
+      "Flow"."toAreaId"
     ORDER BY
-      "Flow"."value" DESC
-    LIMIT 500;
+      "totalValue" DESC
+    LIMIT 250;
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);
@@ -85,6 +73,8 @@ export async function GET(
       properties: {
         fromAreaId: f.fromAreaId,
         toAreaId: f.toAreaId,
+        totalValue: flows.find((flow) => flow.toAreaId === f.toAreaId)
+          ?.totalValue,
       },
       geometry: JSON.parse(f.geojson),
     })),

--- a/src/app/components/map/layers/area-flows.tsx
+++ b/src/app/components/map/layers/area-flows.tsx
@@ -74,7 +74,8 @@ const AreaFlowsLayer = ({ areaId }: { areaId: string }) => {
           visibility: "none",
         }}
         paint={{
-          "line-color": ["get", "color"],
+          "line-color": "#ffffff",
+          "line-opacity": 0.7,
           "line-width": [
             "interpolate",
             ["linear"],
@@ -82,7 +83,7 @@ const AreaFlowsLayer = ({ areaId }: { areaId: string }) => {
             0,
             2,
             50000000000,
-            20,
+            50,
           ],
         }}
       />

--- a/src/app/components/map/state/machine.ts
+++ b/src/app/components/map/state/machine.ts
@@ -511,6 +511,7 @@ export const globeViewMachine = createMachine(
         );
         m.setLayoutProperty("destination-areas-fill", "visibility", "visible");
         m.setLayoutProperty("area-flows", "visibility", "visible");
+        m.setLayoutProperty("area-flows-outline", "visibility", "visible");
 
         return { destinationPortsIds, legend: null };
       }),
@@ -528,6 +529,7 @@ export const globeViewMachine = createMachine(
           );
           m.setLayoutProperty("destination-areas-fill", "visibility", "none");
           m.setLayoutProperty("area-flows", "visibility", "none");
+          m.setLayoutProperty("area-flows-outline", "visibility", "none");
         }
 
         return {


### PR DESCRIPTION
This PR attempts to improve the styling for transportation flows between producing and consuming areas. WIP

So far:
1. Increased to 250 edges (from 100)
2. Set line color as white with 70% opacity
3. Set line thickness range to be wider (high-volume routes are now wider).

<img width="964" alt="image" src="https://github.com/user-attachments/assets/70162de5-c3c9-4252-b9b1-8db30dc8d9b6" />

To-do:

- [ ] Aggregate all food groups to calculate line thickness
- [ ] Consider changing upper bounds (currently `50000000000`)
