### PR TITLE
Increase number of flows for transportation view

### DIFF
--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -67,7 +67,7 @@ export async function GET(
       "foodGroupSlug"
     ORDER BY
       "totalValue" DESC
-    LIMIT 200
+    LIMIT 150
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -67,7 +67,7 @@ export async function GET(
       "foodGroupSlug"
     ORDER BY
       "totalValue" DESC
-    LIMIT 750
+    LIMIT 500
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -67,7 +67,7 @@ export async function GET(
       "foodGroupSlug"
     ORDER BY
       "totalValue" DESC
-    LIMIT 150
+    LIMIT 100
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -67,7 +67,7 @@ export async function GET(
       "foodGroupSlug"
     ORDER BY
       "totalValue" DESC
-    LIMIT 10
+    LIMIT 200
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -67,7 +67,7 @@ export async function GET(
       "foodGroupSlug"
     ORDER BY
       "totalValue" DESC
-    LIMIT 100
+    LIMIT 750
   `;
 
   const toAreaIds = flows.map((f) => f.toAreaId);

--- a/src/app/api/areas/[id]/route.ts
+++ b/src/app/api/areas/[id]/route.ts
@@ -103,7 +103,7 @@ export async function GET(
             ),
             ST_Transform("Node"."geom", 4326)
           ) ASC
-          LIMIT 10;
+          LIMIT 1;
         `,
     ])) as [
       { geojson: string }[],

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -25,9 +25,9 @@ export const PARTICLE_CONFIG = {
 
   particleCountScaling: {
     minParticles: 1,
-    maxParticles: 10,
+    maxParticles: 7,
     minLengthKm: 400,
     maxLengthKm: 40000,
-    maxParticlesPerFoodGroupPerGeometry: 10,
+    maxParticlesPerFoodGroupPerGeometry: 3,
   },
 } as const;

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -2,7 +2,7 @@ import { Color } from "@deck.gl/core";
 
 export const PARTICLE_CONFIG = {
   animation: {
-    fps: 30, // Controls how smooth the animation is
+    fps: 15, // Controls how smooth the animation is
     loopLength: 100, // How many frames before the animation loops
   },
 

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -16,7 +16,7 @@ export const PARTICLE_CONFIG = {
   },
 
   tripGeneration: {
-    maxPoints: 7, // Maximum number of points per trip
+    maxPoints: 5, // Maximum number of points per trip
     minSpacing: 1000, // Minimum spacing in meters (1km)
     maxSpacing: 100000, // Maximum spacing in meters (100km)
     initialSpacing: 10000, // Default initial spacing in meters (10km)

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -2,7 +2,7 @@ import { Color } from "@deck.gl/core";
 
 export const PARTICLE_CONFIG = {
   animation: {
-    fps: 20, // Controls how smooth the animation is
+    fps: 30, // Controls how smooth the animation is
     loopLength: 100, // How many frames before the animation loops
   },
 
@@ -16,11 +16,11 @@ export const PARTICLE_CONFIG = {
   },
 
   tripGeneration: {
-    maxPoints: 50, // Maximum number of points per trip
+    maxPoints: 7, // Maximum number of points per trip
     minSpacing: 1000, // Minimum spacing in meters (1km)
     maxSpacing: 100000, // Maximum spacing in meters (100km)
     initialSpacing: 10000, // Default initial spacing in meters (10km)
-    maxIterations: 10, // Maximum iterations for finding optimal spacing
+    maxIterations: 5, // Maximum iterations for finding optimal spacing
   },
 
   particleCountScaling: {

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -2,7 +2,7 @@ import { Color } from "@deck.gl/core";
 
 export const PARTICLE_CONFIG = {
   animation: {
-    fps: 20, // Controls how smooth the animation is
+    fps: 15, // Controls how smooth the animation is
     loopLength: 100, // How many frames before the animation loops
   },
 
@@ -16,18 +16,18 @@ export const PARTICLE_CONFIG = {
   },
 
   tripGeneration: {
-    maxPoints: 5, // Maximum number of points per trip
-    minSpacing: 1000, // Minimum spacing in meters (1km)
-    maxSpacing: 100000, // Maximum spacing in meters (100km)
-    initialSpacing: 10000, // Default initial spacing in meters (10km)
+    maxPoints: 2, // Maximum number of points per trip
+    minSpacing: 4000, // Minimum spacing in meters (1km)
+    maxSpacing: 1000000, // Maximum spacing in meters (100km)
+    initialSpacing: 100000, // Default initial spacing in meters (10km)
     maxIterations: 5, // Maximum iterations for finding optimal spacing
   },
 
   particleCountScaling: {
     minParticles: 1,
-    maxParticles: 7,
+    maxParticles: 2,
     minLengthKm: 400,
     maxLengthKm: 40000,
-    maxParticlesPerFoodGroupPerGeometry: 3,
+    maxParticlesPerFoodGroupPerGeometry: 2,
   },
 } as const;

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -2,7 +2,7 @@ import { Color } from "@deck.gl/core";
 
 export const PARTICLE_CONFIG = {
   animation: {
-    fps: 15, // Controls how smooth the animation is
+    fps: 20, // Controls how smooth the animation is
     loopLength: 100, // How many frames before the animation loops
   },
 


### PR DESCRIPTION
This PR increases the number of flows that are shown in the transportation view, to better show the full extent of calorie flows. In its current form, it comes at the cost of performance (i.e., the more flows, the slower the app responds).

To mitigate the sluggishness, I've also made some tweaks to the particle generation and styling.

| Current (staging) | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3d799030-69af-4054-8518-fcb51b4257de) | ![image](https://github.com/user-attachments/assets/1c5db17c-f834-43c8-ab79-d94c6feb521e) | 

@vgeorge this is ready for review.

Please check some regions with high flow counts and total calories, such as from the table you provided:

```
 BEL.2_1    | Vlaanderen    |      65031
 BEL.3_1    | Wallonie      |      45482
 USA.5_1    | California    |      37951
 ESP.1_1    | Andalucía     |      35304
 NLD.14_1   | Zuid-Holland  |      31650
 NLD.8_1    | Noord-Brabant |      29173
 ARE.1_1    | Abu Dhabi     |      29059
 ITA.10_1   | Lombardia     |      28253
 ESP.6_1    | Cataluña      |      27996
 CAN.9_1    | Ontario       |      27301
```

Please have a look for three things:

1. Does the app ever feel too sluggish? If so, we can reduce the number of flows
2. Are there too many small "reverse" particles? If so, we can reduce the number of flows (I noticed these became more visible as we increase the number of flows)
3. Do the particles match the flow geometries (the white lines) well enough?