### PR TITLE
Fix MultiLineString handling in particle flow geometries

### DIFF
--- a/src/app/api/areas/[id]/flows/route.ts
+++ b/src/app/api/areas/[id]/flows/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
-import { FeatureCollection, LineString } from "geojson";
+import { FeatureCollection, LineString, MultiLineString } from "geojson";
 
 const GEOMETRY_SIMPLIFICATION_TOLERANCE = 1;
 const COORDINATE_PRECISION_GRID = 0.01;
@@ -21,7 +21,7 @@ interface FlowRow {
 }
 
 type FlowGeometryGeojson = FeatureCollection<
-  LineString,
+  LineString | MultiLineString,
   {
     fromAreaId: string;
     toAreaId: string;


### PR DESCRIPTION
The API was returning MultiLineString geometries from ST_LineMerge(), but the client code only expected LineString.

This updates type definition to correctly reflect that ST_LineMerge can return either LineString or MultiLineString.

@wrynearson ready for review. I suggest visiting an area that has flows crossing the anti-meridian, like http://localhost:3000/area/BRA.4_1?view=transportation