### PR TITLE
Update styling to match designs

### DIFF
--- a/src/app/components/charts/list-bars.tsx
+++ b/src/app/components/charts/list-bars.tsx
@@ -37,7 +37,7 @@ function Bar({
   const formattedValue = formatKeyIndicator(value, formatType, decimalPlaces);
 
   return (
-    <div className="my-4">
+    <div className="mb-8">
       <div className="flex text-sm mb-1">
         <div className="flex-grow">
           <span aria-hidden="true" className="mr-2" style={{ color }}>

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -148,7 +148,8 @@ function GlobeInner() {
         mapboxAccessToken={mapboxAccessToken}
         ref={mapRef}
         initialViewState={worldViewState}
-        minZoom="2" // to avoid duplicate continents
+        minZoom={2} // to avoid duplicate continents
+        maxZoom={8} // to avoid overzoom
         onClick={onClick}
         onLoad={() => {
           actorRef.send({

--- a/src/app/components/map/index.tsx
+++ b/src/app/components/map/index.tsx
@@ -148,6 +148,7 @@ function GlobeInner() {
         mapboxAccessToken={mapboxAccessToken}
         ref={mapRef}
         initialViewState={worldViewState}
+        minZoom="2" // to avoid duplicate continents
         onClick={onClick}
         onLoad={() => {
           actorRef.send({

--- a/src/app/components/map/layers/particles/config.ts
+++ b/src/app/components/map/layers/particles/config.ts
@@ -8,7 +8,7 @@ export const PARTICLE_CONFIG = {
 
   appearance: {
     trailLength: 5,
-    widthMinPixels: 5,
+    widthMinPixels: 2,
     fadeTrail: true,
     capRounded: true,
     jointRounded: true,

--- a/src/app/components/map/layers/particles/layers/flow-paths-layer.tsx
+++ b/src/app/components/map/layers/particles/layers/flow-paths-layer.tsx
@@ -16,8 +16,9 @@ export function FlowPathsLayer({ pathsData }: FlowPathsLayerProps) {
         id="flow-paths-lines"
         type="line"
         paint={{
-          "line-color": "rgba(255, 255, 255, 0.5)",
-          "line-width": 5,
+          "line-color": "rgb(255, 255, 255)",
+          "line-width": 2.5,
+          "line-opacity": 0.5,
         }}
         layout={{
           "line-join": "round",

--- a/src/app/components/page-section.tsx
+++ b/src/app/components/page-section.tsx
@@ -49,7 +49,7 @@ export interface IPageSection {
 
 export function PageSection({ id, children, className = "" }: IPageSection) {
   return (
-    <div id={id} className={`p-4 ${className}`}>
+    <div id={id} className={`py-8 px-6 ${className}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
This PR updates some design elements throughout the app to match the [Figma file](https://www.figma.com/design/zz7755JriAt4vKJsdV3Dcr/Global-Food-Twin?node-id=1217-5621&t=wRfriip8VU04y57P-0).

- [x] Fixes blending mode of particle paths
- [x] Reduces particle path width
- [x] Reduces particle max width
- [x] Set min zoom (and maybe set max extents)
- [ ] Remove zoom on side bar interaction
- [x] Add 24px padding to match Figma file
- [ ] ~Remove "Regions and countries" label at top of sidebar~

I wasn't able to get to all of @faustoperez's [feedback](https://developmentseed.slack.com/archives/C050TSDNTMM/p1749200786335729?thread_ts=1749197899.296219&cid=C050TSDNTMM), but I think this gets us closer to the approved designs