### PR TITLE
Fix page section padding, add separator

### DIFF
--- a/src/app/(home)/area/[areaId]/page.tsx
+++ b/src/app/(home)/area/[areaId]/page.tsx
@@ -335,6 +335,8 @@ const AreaPage = async ({
               />
             </MetricRow>
 
+            <div className="border-b border-neutral-200 mx-0 my-8" />
+
             <ListBars
               showPercentage
               formatType="weight"

--- a/src/app/components/page-header.tsx
+++ b/src/app/components/page-header.tsx
@@ -17,7 +17,7 @@ function getTypeLabel(itemType: EItemType) {
 
 function PageHeader({ title, itemType }: IPageHeader) {
   return (
-    <div className="bg-neutral-900 text-white p-4 flex gap-4 items-start">
+    <div className="bg-neutral-900 text-white p-6 flex gap-4 items-start">
       <div className="flex-grow">
         <div className="flex items-center gap-2 mb-4">
           <TypeIcon itemType={itemType} />


### PR DESCRIPTION
Changes:

- Fix padding on page header (24px)
- Fix padding on page section (24x32px)
- Add separator between indicators and food group bards

cc @faustoperez 