### PR TITLE
feat: Fix land files reference and optimize ingest

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,8 @@ DUMP_FILE_PATH="./app-data/db_dump"
 
 SEED_DATA_PATH="./app-data/seed"
 
+INGEST_LOGS_PATH="./app-data/logs"
+
 # Environment variables for client usage
 NEXT_PUBLIC_XSTATE_INSPECT=false
 

--- a/prisma/seed/config.ts
+++ b/prisma/seed/config.ts
@@ -10,6 +10,10 @@ export const SEED_DATA_PATH = path.resolve(
   process.env.SEED_DATA_PATH as string
 );
 
+export const INGEST_LOGS_PATH = path.resolve(
+  process.env.INGEST_LOGS_PATH || path.join(process.cwd(), "logs")
+);
+
 // Development mode flag
 export const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
 

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -18,7 +18,6 @@ import { getEdgesId } from "./utils/get-edges-id";
 
 const TRANSACTION_TIMEOUT = 60 * 60 * 1000;
 const SKIP_FOOD_GROUPS = 0; // Skip food groups that have already been ingested
-const FLOW_FILE_SIZE_LIMIT_MB = 10;
 
 // Create flow-specific logger
 const flowLogger = createFlowLogger();
@@ -215,13 +214,6 @@ async function ingestFlowFile(
   const { foodGroup } = foodGroupFile;
   log(`Ingesting flows for ${foodGroup.id} - ${foodGroup.name}...`);
 
-  // Check if the file is too large to ingest
-  const fileSize = fs.statSync(foodGroupFile.path).size;
-  const sizeMB = fileSize / (1024 * 1024);
-  if (sizeMB > FLOW_FILE_SIZE_LIMIT_MB) {
-    log(`Skipping large file (${sizeMB.toFixed(1)}MB)`);
-    return;
-  }
   // Query existing flow geometries for this run
   const existingGeometriesQueryResult = (await prisma.$queryRaw`
     SELECT 

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -106,11 +106,13 @@ export const ingestFlows = async (
         return false;
       }
       const filename = path.basename(filePath);
-      // Only include files from foodgroup1 directories
+      // Include files from foodgroup1 directories OR Land directories
       return (
         filename.startsWith("Flows_") &&
         filename.endsWith(".csv.gz") &&
-        filePath.includes("/foodgroup1/")
+        (filePath.includes("/foodgroup1/") ||
+          filePath.includes("/Land_Domestic/") ||
+          filePath.includes("/Land_ReExports/"))
       );
     }
   );

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -4,6 +4,7 @@ import { execa } from "execa";
 import { parse } from "csv-parse";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { generateNumericId, listFilesRecursively, log } from "./utils";
+import { createFlowLogger } from "./utils/logger";
 
 import sqlite3 from "sqlite3";
 import { open, Database } from "sqlite";
@@ -19,19 +20,11 @@ const TRANSACTION_TIMEOUT = 60 * 60 * 1000;
 const SKIP_FOOD_GROUPS = 0; // Skip food groups that have already been ingested
 const FLOW_FILE_SIZE_LIMIT_MB = 10;
 
-const filesIngestLog = path.resolve(SEED_DATA_PATH, "file_ingest_log.txt");
-export function logFileIngest(message: Error | string) {
-  const currentTimestamp = new Date().toISOString();
-  const logMessage =
-    message instanceof Error
-      ? `${currentTimestamp}: ${message.stack}\n`
-      : `${currentTimestamp}: ${message}\n`;
-  // eslint-disable-next-line no-console
-  console.log(logMessage);
-
-  // Log to file
-  fs.appendFileSync(filesIngestLog, logMessage);
-}
+// Create flow-specific logger
+const flowLogger = createFlowLogger();
+export const logFileIngest = (message: Error | string) => {
+  flowLogger.logError(message);
+};
 
 enum FlowType {
   SEA_DOMESTIC = "SEA_DOMESTIC",

--- a/prisma/seed/flows.ts
+++ b/prisma/seed/flows.ts
@@ -19,7 +19,7 @@ import { getEdgesId } from "./utils/get-edges-id";
 
 const TRANSACTION_TIMEOUT = 60 * 60 * 1000;
 const SKIP_FOOD_GROUPS = 0; // Skip food groups that have already been ingested
-const MAX_CONCURRENT_GEOMETRIES = 30;
+const MAX_CONCURRENT_GEOMETRIES = 500;
 
 // Create flow-specific logger
 const flowLogger = createFlowLogger(INGESTION_MODE);

--- a/prisma/seed/utils/logger.ts
+++ b/prisma/seed/utils/logger.ts
@@ -1,0 +1,77 @@
+import fs from "fs-extra";
+import path from "path";
+import { INGEST_LOGS_PATH } from "../config";
+
+export interface LoggerOptions {
+  logFileName?: string;
+  ingestMode?: string;
+  logToFile?: boolean;
+}
+
+export class Logger {
+  private logFilePath: string | null = null;
+  private lastTimestamp = Date.now();
+
+  constructor(options: LoggerOptions = {}) {
+    if (options.logToFile !== false) {
+      const timestamp = new Date()
+        .toISOString()
+        .replace(/[:.]/g, "-")
+        .slice(0, 19);
+      const ingestMode =
+        options.ingestMode || process.env.INGESTION_MODE || "default";
+      const logsDir = INGEST_LOGS_PATH;
+
+      fs.ensureDirSync(logsDir);
+
+      const fileName =
+        options.logFileName || `ingest_log_${timestamp}_${ingestMode}.txt`;
+      this.logFilePath = path.resolve(logsDir, fileName);
+    }
+  }
+
+  log(message: string) {
+    const currentTimestamp = Date.now();
+    const diff = ((currentTimestamp - this.lastTimestamp) / 1000).toFixed(2);
+    const formattedTimestamp = new Date(currentTimestamp).toISOString();
+    const logMessage = `[${formattedTimestamp}] (+${diff}s) ${message}`;
+
+    // eslint-disable-next-line no-console
+    console.log(logMessage);
+
+    if (this.logFilePath) {
+      fs.appendFileSync(this.logFilePath, logMessage + "\n");
+    }
+
+    this.lastTimestamp = currentTimestamp;
+  }
+
+  logError(error: Error | string) {
+    const currentTimestamp = new Date().toISOString();
+    const logMessage =
+      error instanceof Error
+        ? `${currentTimestamp}: ${error.stack}\n`
+        : `${currentTimestamp}: ${error}\n`;
+
+    // eslint-disable-next-line no-console
+    console.error(logMessage);
+
+    if (this.logFilePath) {
+      fs.appendFileSync(this.logFilePath, logMessage);
+    }
+  }
+}
+
+// Create a default logger instance for backward compatibility
+export const createFlowLogger = (ingestMode?: string) => {
+  return new Logger({
+    logFileName: `flow_ingest_log_${new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-")
+      .slice(
+        0,
+        19
+      )}_${ingestMode || process.env.INGESTION_MODE || "default"}.txt`,
+    ingestMode,
+  });
+};


### PR DESCRIPTION
Contributes to #123.

The land files in the Drive folder were not following the expected filename pattern and were not ingested in the last run, available in the staging website. This PR updates the script to detect the actual pattern used as a quick fix. In future data updates, the land files should have the correct filename pattern. The production database now includes the land files. cc @kushankb

The last version of the ingest script took about a week to run, which was too long. We needed a faster ingest to introduce the land files for the app launch. To achieve this, optimizations were added to the flow geometries generation using parallelization and batch inserts. With this version, the ingest now takes about 8 hours.

